### PR TITLE
chore: Remove extraneous comma in JSON

### DIFF
--- a/static/api-docs/openapi.json
+++ b/static/api-docs/openapi.json
@@ -1825,7 +1825,7 @@
 			"OnlineStatus": {
 			  "title": "Online status",
 				"description": "Whether or not the member is connected.",
-			  "type": "boolean",
+			  "type": "boolean"
 			},
 			"LoginResponse": {
 				"type": "object",


### PR DESCRIPTION
Literally a one character diff