### PR TITLE
chore: Move from `log` to `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,29 +1126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,7 +2829,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "cucumber",
- "env_logger",
  "futures",
  "futures-util",
  "http-auth-basic",
@@ -2860,7 +2836,6 @@ dependencies = [
  "iso8601-timestamp",
  "lazy_static",
  "linked-hash-map",
- "log",
  "migration",
  "regex",
  "rocket",
@@ -2872,6 +2847,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
@@ -3882,7 +3858,6 @@ dependencies = [
  "insta",
  "jwt",
  "lettre",
- "log",
  "migration",
  "minidom",
  "parking_lot",
@@ -3898,6 +3873,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "url_serde",
  "urlencoding",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ chrono = "0.4"
 cucumber = "0.21"
 email_address = "0.2"
 entity = { path = "./entity" }
-env_logger = "0.11"
 figment = { version = "0.10", features = ["toml"] }
 form_urlencoded = "1"
 futures = "0.3"
@@ -53,7 +52,6 @@ lettre = { version = "0.11", features = [
     "builder",
 ], default-features = false }
 linked-hash-map = "0.5"
-log = { version = "0.4", features = ["std"] }
 migration = { path = "./migration" }
 minidom = { git = "https://gitlab.com/nesium/xmpp-rs", branch = "main" }
 parking_lot = "0.12"
@@ -89,6 +87,7 @@ thiserror = "1"
 # https://github.com/time-rs/time/issues/681
 time = "=0.3.36"
 tokio = "1"
+tracing = { version = "0.1" }
 tracing-subscriber = "0.3"
 url_serde = "0.2"
 urlencoding = "2"
@@ -100,13 +99,11 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
-env_logger = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 http-auth-basic = { workspace = true }
 iso8601-duration = { workspace = true }
 iso8601-timestamp = { workspace = true }
-log = { workspace = true }
 migration = { workspace = true }
 rocket = { workspace = true }
 sea-orm-rocket = { workspace = true }
@@ -117,6 +114,8 @@ service = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -17,7 +17,6 @@ form_urlencoded = { workspace = true }
 hmac = { workspace = true }
 jwt = { workspace = true }
 lettre = { workspace = true }
-log = { workspace = true }
 minidom = { workspace = true }
 parking_lot = { workspace = true }
 prose-xmpp = { workspace = true }
@@ -32,6 +31,7 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 url_serde = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/service/src/controllers/invitation_controller.rs
+++ b/service/src/controllers/invitation_controller.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
 use entity::model::{InvitationContact, InvitationStatus, JIDNode, MemberRole};
-use log::{debug, error, warn};
 use prose_xmpp::BareJid;
 #[cfg(debug_assertions)]
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use sea_orm::{DatabaseConnection, DbErr, ItemsAndPagesNumber, ModelTrait as _};
 use secrecy::{ExposeSecret as _, SecretString};
+use tracing::{debug, error, warn};
 
 use crate::{
     config::Config as AppConfig,

--- a/service/src/controllers/member_controller.rs
+++ b/service/src/controllers/member_controller.rs
@@ -4,9 +4,9 @@
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 use chrono::{DateTime, Utc};
-use log::{debug, trace, warn};
 use prose_xmpp::BareJid;
 use sea_orm::{DatabaseConnection, DbErr, ItemsAndPagesNumber};
+use tracing::{debug, trace, warn};
 
 use crate::{model::Member, repositories::MemberRepository, services::xmpp_service::XmppService};
 

--- a/service/src/dependencies/any_notifier/generic.rs
+++ b/service/src/dependencies/any_notifier/generic.rs
@@ -6,7 +6,7 @@
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 use entity::notification::NotificationPayload;
-use log::{debug, info};
+use tracing::{debug, info};
 
 use crate::config::ConfigBranding;
 

--- a/service/src/dependencies/notifier.rs
+++ b/service/src/dependencies/notifier.rs
@@ -85,7 +85,7 @@ mod live {
 
 #[cfg(debug_assertions)]
 mod logging {
-    use log::debug;
+    use tracing::debug;
 
     use super::NotifierImpl;
     use crate::{

--- a/service/src/prosody/prosody_admin_rest.rs
+++ b/service/src/prosody/prosody_admin_rest.rs
@@ -7,7 +7,6 @@ use std::{fs::File, future::Future, io::Write as _, path::PathBuf};
 
 use async_trait::async_trait;
 use entity::{model::MemberRole, server_config};
-use log::debug;
 use prose_xmpp::BareJid;
 use reqwest::{
     header::HeaderMap, Client as HttpClient, Method, RequestBuilder, Response, StatusCode,
@@ -15,6 +14,7 @@ use reqwest::{
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
 use tokio::runtime::Handle;
+use tracing::debug;
 
 use crate::{
     config::Config,

--- a/service/src/prosody/prosody_oauth2.rs
+++ b/service/src/prosody/prosody_oauth2.rs
@@ -3,12 +3,12 @@
 // Copyright: 2024, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use log::debug;
 use prose_xmpp::BareJid;
 use reqwest::{Client as HttpClient, RequestBuilder, Response, StatusCode};
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
 use tokio::runtime::Handle;
+use tracing::debug;
 
 use crate::config::Config;
 

--- a/service/src/prosody/prosody_rest.rs
+++ b/service/src/prosody/prosody_rest.rs
@@ -7,7 +7,6 @@ use std::{fmt::Debug, sync::Arc};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use log::{debug, trace};
 use minidom::Element;
 use parking_lot::RwLock;
 use prose_xmpp::{
@@ -20,6 +19,7 @@ use prose_xmpp::{
 use reqwest::Client as HttpClient;
 use secrecy::{ExposeSecret as _, SecretString};
 use tokio::runtime::Handle;
+use tracing::{debug, trace};
 use xmpp_parsers::FullJid;
 
 /// Rust interface to [`mod_http_rest`](https://hg.prosody.im/prosody-modules/file/tip/mod_http_rest).

--- a/service/src/services/live_xmpp_service/live_xmpp_service.rs
+++ b/service/src/services/live_xmpp_service/live_xmpp_service.rs
@@ -6,12 +6,12 @@
 use std::str::FromStr as _;
 use std::sync::Arc;
 
-use log::{debug, trace};
 use prose_xmpp::mods::{self, AvatarData};
 use prose_xmpp::stanza::avatar::{self, ImageId};
 use prose_xmpp::{BareJid, IDProvider};
 use reqwest::Client as HttpClient;
 use tokio::runtime::Handle;
+use tracing::{debug, trace};
 use xmpp_parsers::hashes::Sha1HexAttribute;
 use xmpp_parsers::jid::ResourcePart;
 

--- a/service/src/services/server_manager.rs
+++ b/service/src/services/server_manager.rs
@@ -6,8 +6,8 @@
 use std::sync::{RwLock, RwLockWriteGuard};
 
 use entity::server_config;
-use log::trace;
 use sea_orm::DbErr;
+use tracing::trace;
 
 use crate::config::Config as AppConfig;
 use crate::model::{DateLike, Duration, PossiblyInfinite, ServerConfig};

--- a/service/src/services/xmpp_service.rs
+++ b/service/src/services/xmpp_service.rs
@@ -7,11 +7,11 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use log::debug;
 use prose_xmpp::mods::AvatarData;
 use prose_xmpp::stanza::vcard::Nickname;
 use prose_xmpp::{BareJid, ConnectionError, RequestError};
 use secrecy::SecretString;
+use tracing::debug;
 
 pub use super::live_xmpp_service::LiveXmppService;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ pub mod v1;
 use error::Error;
 use guards::Db;
 
-use log::{debug, info};
 use migration::MigratorTrait;
 use rocket::fairing::{self, AdHoc};
 use rocket::fs::{FileServer, NamedFile};
@@ -32,6 +31,7 @@ use service::{
         server_manager::ServerManager, xmpp_service::XmppServiceInner,
     },
 };
+use tracing::{debug, info};
 
 /// A custom `Rocket` with a default configuration.
 pub fn custom_rocket(

--- a/tests/behavior.rs
+++ b/tests/behavior.rs
@@ -15,7 +15,6 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use cucumber::{given, then, World};
 use cucumber_parameters::HTTPStatus;
 use lazy_static::lazy_static;
-use log::debug;
 use mock_auth_service::MockAuthService;
 use mock_notifier::{MockNotifier, MockNotifierState};
 use mock_server_ctl::{MockServerCtl, MockServerCtlState};
@@ -47,6 +46,7 @@ use service::{
 };
 use tokio::runtime::Handle;
 use tokio::task;
+use tracing::debug;
 use tracing_subscriber::{
     filter::{self, LevelFilter},
     fmt::format::{self, Format},


### PR DESCRIPTION
We're not doing real tracing yet but it'll come one day so we have no reason to use `log` while most dependencies use `tracing`.