### PR TITLE
chore: Migrate dependencies to async traits

### DIFF
--- a/service/src/services/auth_service.rs
+++ b/service/src/services/auth_service.rs
@@ -38,9 +38,14 @@ impl Deref for AuthService {
     }
 }
 
+#[async_trait::async_trait]
 pub trait AuthServiceImpl: Debug + Sync + Send {
     /// Generates a token from a username and password.
-    fn log_in(&self, jid: &BareJid, password: &SecretString) -> Result<SecretString, AuthError>;
+    async fn log_in(
+        &self,
+        jid: &BareJid,
+        password: &SecretString,
+    ) -> Result<SecretString, AuthError>;
     fn verify(&self, jwt: &SecretString) -> Result<JWT, JWTError>;
 }
 
@@ -59,9 +64,14 @@ impl LiveAuthService {
     }
 }
 
+#[async_trait::async_trait]
 impl AuthServiceImpl for LiveAuthService {
-    fn log_in(&self, jid: &BareJid, password: &SecretString) -> Result<SecretString, AuthError> {
-        let Some(prosody_token) = self.prosody_oauth2.log_in(jid, password)? else {
+    async fn log_in(
+        &self,
+        jid: &BareJid,
+        password: &SecretString,
+    ) -> Result<SecretString, AuthError> {
+        let Some(prosody_token) = self.prosody_oauth2.log_in(jid, password).await? else {
             Err(AuthError::InvalidCredentials)?
         };
 

--- a/service/src/services/server_ctl.rs
+++ b/service/src/services/server_ctl.rs
@@ -41,25 +41,27 @@ impl Deref for ServerCtl {
 
 /// Abstraction over `prosodyctl` in case we want to switch to another server.
 /// Also facilitates testing.
+#[async_trait::async_trait]
 pub trait ServerCtlImpl: Debug + Sync + Send {
-    fn save_config(
+    async fn save_config(
         &self,
         server_config: &server_config::Model,
         app_config: &Config,
     ) -> Result<(), Error>;
-    fn reload(&self) -> Result<(), Error>;
+    async fn reload(&self) -> Result<(), Error>;
 
-    fn add_user(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error>;
-    fn remove_user(&self, jid: &BareJid) -> Result<(), Error>;
-    fn set_user_role(&self, jid: &BareJid, role: &MemberRole) -> Result<(), Error>;
-    fn add_user_with_role(
+    async fn add_user(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error>;
+    async fn remove_user(&self, jid: &BareJid) -> Result<(), Error>;
+    async fn set_user_role(&self, jid: &BareJid, role: &MemberRole) -> Result<(), Error>;
+    async fn add_user_with_role(
         &self,
         jid: &BareJid,
         password: &SecretString,
         role: &MemberRole,
     ) -> Result<(), Error> {
-        self.add_user(jid, password)
-            .and_then(|_| self.set_user_role(jid, role))
+        self.add_user(jid, password).await?;
+        self.set_user_role(jid, role).await?;
+        Ok(())
     }
 }
 

--- a/service/src/services/server_manager.rs
+++ b/service/src/services/server_manager.rs
@@ -65,7 +65,7 @@ impl<'r> ServerManager<'r> {
 
         if new_server_config != old_server_config {
             trace!("Server config has changed, reloading…");
-            self.reload(&new_server_config)?;
+            self.reload(&new_server_config).await?;
         } else {
             trace!("Server config hasn't changed, no need to reload.");
         }
@@ -74,20 +74,22 @@ impl<'r> ServerManager<'r> {
     }
 
     /// Reload the XMPP server using the server configuration stored in `self`.
-    pub fn reload_current(&self) -> Result<(), Error> {
-        self.reload(&self.server_config_mut())
+    pub async fn reload_current(&self) -> Result<(), Error> {
+        self.reload(&self.server_config()).await
     }
 
     /// Reload the XMPP server using the server configuration passed as an argument.
-    fn reload(&self, server_config: &ServerConfig) -> Result<(), Error> {
+    async fn reload(&self, server_config: &ServerConfig) -> Result<(), Error> {
         let server_ctl = self.server_ctl;
 
         // Save new server config
         trace!("Saving server config…");
-        server_ctl.save_config(&server_config, self.app_config)?;
+        server_ctl
+            .save_config(&server_config, self.app_config)
+            .await?;
         // Reload server config
         trace!("Reloading XMPP server…");
-        server_ctl.reload()?;
+        server_ctl.reload().await?;
 
         Ok(())
     }
@@ -139,8 +141,8 @@ impl<'r> ServerManager<'r> {
         //   but better than nothing.
         // TODO: Find a way to rollback XMPP server changes.
         {
-            server_ctl.save_config(&server_config, app_config)?;
-            server_ctl.reload()?;
+            server_ctl.save_config(&server_config, app_config).await?;
+            server_ctl.reload().await?;
         }
 
         // Commit the transaction only if the admin user was

--- a/service/src/services/user_service.rs
+++ b/service/src/services/user_service.rs
@@ -64,10 +64,12 @@ impl<'r> UserService<'r> {
 
         server_ctl
             .add_user(jid, &password)
+            .await
             .map_err(UserCreateError::XmppServerCannotCreateUser)?;
         if let Some(role) = role {
             server_ctl
                 .set_user_role(jid, &role)
+                .await
                 .map_err(UserCreateError::XmppServerCannotSetUserRole)?;
         }
 
@@ -76,6 +78,7 @@ impl<'r> UserService<'r> {
         let jwt = self
             .auth_service
             .log_in(jid, &password)
+            .await
             .expect("User was created with credentials which doesn't work.");
         let jwt = self
             .auth_service
@@ -94,6 +97,7 @@ impl<'r> UserService<'r> {
         // TODO: Create the vCard using a display name instead of the nickname
         xmpp_service
             .create_own_vcard(nickname)
+            .await
             .map_err(UserCreateError::CouldNotCreateVCard)?;
         // xmpp_service.set_own_nickname(nickname)?;
 

--- a/service/src/services/xmpp_service.rs
+++ b/service/src/services/xmpp_service.rs
@@ -51,44 +51,45 @@ impl XmppServiceInner {
 pub type VCard = prose_xmpp::stanza::VCard4;
 
 impl<'r> XmppService<'r> {
-    pub fn get_vcard(&self, jid: &BareJid) -> Result<Option<VCard>, XmppServiceError> {
-        self.deref().get_vcard(&self.ctx, jid)
+    pub async fn get_vcard(&self, jid: &BareJid) -> Result<Option<VCard>, XmppServiceError> {
+        self.deref().get_vcard(&self.ctx, jid).await
     }
-    pub fn set_own_vcard(&self, vcard: &VCard) -> Result<(), XmppServiceError> {
-        self.deref().set_own_vcard(&self.ctx, vcard)
+    pub async fn set_own_vcard(&self, vcard: &VCard) -> Result<(), XmppServiceError> {
+        self.deref().set_own_vcard(&self.ctx, vcard).await
     }
-    pub fn create_own_vcard(&self, name: &str) -> Result<(), XmppServiceError> {
-        self.deref().create_own_vcard(&self.ctx, name)
+    pub async fn create_own_vcard(&self, name: &str) -> Result<(), XmppServiceError> {
+        self.deref().create_own_vcard(&self.ctx, name).await
     }
-    pub fn set_own_nickname(&self, nickname: &str) -> Result<(), XmppServiceError> {
-        self.deref().set_own_nickname(&self.ctx, nickname)
-    }
-
-    pub fn get_avatar(&self, jid: &BareJid) -> Result<Option<AvatarData>, XmppServiceError> {
-        self.deref().get_avatar(&self.ctx, jid)
-    }
-    pub fn set_own_avatar(&self, png_data: Vec<u8>) -> Result<(), XmppServiceError> {
-        self.deref().set_own_avatar(&self.ctx, png_data)
+    pub async fn set_own_nickname(&self, nickname: &str) -> Result<(), XmppServiceError> {
+        self.deref().set_own_nickname(&self.ctx, nickname).await
     }
 
-    pub fn is_connected(&self, jid: &BareJid) -> Result<bool, XmppServiceError> {
-        self.deref().is_connected(&self.ctx, jid)
+    pub async fn get_avatar(&self, jid: &BareJid) -> Result<Option<AvatarData>, XmppServiceError> {
+        self.deref().get_avatar(&self.ctx, jid).await
+    }
+    pub async fn set_own_avatar(&self, png_data: Vec<u8>) -> Result<(), XmppServiceError> {
+        self.deref().set_own_avatar(&self.ctx, png_data).await
+    }
+
+    pub async fn is_connected(&self, jid: &BareJid) -> Result<bool, XmppServiceError> {
+        self.deref().is_connected(&self.ctx, jid).await
     }
 }
 
+#[async_trait::async_trait]
 pub trait XmppServiceImpl: Debug + Send + Sync {
-    fn get_vcard(
+    async fn get_vcard(
         &self,
         ctx: &XmppServiceContext,
         jid: &BareJid,
     ) -> Result<Option<VCard>, XmppServiceError>;
-    fn set_own_vcard(
+    async fn set_own_vcard(
         &self,
         ctx: &XmppServiceContext,
         vcard: &VCard,
     ) -> Result<(), XmppServiceError>;
 
-    fn create_own_vcard(
+    async fn create_own_vcard(
         &self,
         ctx: &XmppServiceContext,
         name: &str,
@@ -97,35 +98,38 @@ pub trait XmppServiceImpl: Debug + Send + Sync {
         vcard.nickname.push(Nickname {
             value: name.to_owned(),
         });
-        self.set_own_vcard(ctx, &vcard)
+        self.set_own_vcard(ctx, &vcard).await
     }
-    fn set_own_nickname(
+    async fn set_own_nickname(
         &self,
         ctx: &XmppServiceContext,
         nickname: &str,
     ) -> Result<(), XmppServiceError> {
         debug!("Setting {}'s nickname to {nickname}…", ctx.bare_jid);
-        let mut vcard = self.get_vcard(ctx, &ctx.bare_jid)?.unwrap_or_default();
+        let mut vcard = self
+            .get_vcard(ctx, &ctx.bare_jid)
+            .await?
+            .unwrap_or_default();
         vcard.nickname = vec![Nickname {
             value: nickname.to_owned(),
         }];
-        self.set_own_vcard(ctx, &vcard)
+        self.set_own_vcard(ctx, &vcard).await
     }
 
-    fn get_avatar(
+    async fn get_avatar(
         &self,
         ctx: &XmppServiceContext,
         jid: &BareJid,
     ) -> Result<Option<AvatarData>, XmppServiceError>;
     // TODO: Allow other MIME types
     // TODO: Allow setting an avatar pointing to a URL
-    fn set_own_avatar(
+    async fn set_own_avatar(
         &self,
         ctx: &XmppServiceContext,
         png_data: Vec<u8>,
     ) -> Result<(), XmppServiceError>;
 
-    fn is_connected(
+    async fn is_connected(
         &self,
         ctx: &XmppServiceContext,
         jid: &BareJid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ async fn server_config_init(rocket: Rocket<Build>) -> fairing::Result {
     match ServerConfigRepository::get(db).await {
         Ok(Some(server_config)) => {
             let server_manager = ServerManager::new(db, app_config, server_ctl, server_config);
-            if let Err(err) = server_manager.reload_current() {
+            if let Err(err) = server_manager.reload_current().await {
                 error!("Could not initialize the XMPP server configuration: {err}");
             }
         }

--- a/src/v1/routes.rs
+++ b/src/v1/routes.rs
@@ -33,12 +33,14 @@ pub struct LoginResponse {
 
 /// Log user in and return an authentication token.
 #[post("/v1/login")]
-pub(super) fn login(
+pub(super) async fn login(
     basic_auth: LazyGuard<BasicAuth>,
     auth_service: &State<AuthService>,
 ) -> R<LoginResponse> {
     let basic_auth = basic_auth.inner?;
-    let token = auth_service.log_in(&basic_auth.jid, &basic_auth.password)?;
+    let token = auth_service
+        .log_in(&basic_auth.jid, &basic_auth.password)
+        .await?;
     let response = LoginResponse {
         token: LoginToken::from(token).into(),
     }

--- a/tests/prelude/mock_auth_service.rs
+++ b/tests/prelude/mock_auth_service.rs
@@ -63,8 +63,9 @@ impl Default for MockAuthServiceState {
     }
 }
 
+#[async_trait::async_trait]
 impl AuthServiceImpl for MockAuthService {
-    fn log_in(
+    async fn log_in(
         &self,
         jid: &BareJid,
         password: &SecretString,

--- a/tests/prelude/mock_server_ctl.rs
+++ b/tests/prelude/mock_server_ctl.rs
@@ -61,15 +61,20 @@ impl Default for MockServerCtlState {
     }
 }
 
+#[async_trait::async_trait]
 impl ServerCtlImpl for MockServerCtl {
-    fn save_config(&self, server_config: &ServerConfig, app_config: &Config) -> Result<(), Error> {
+    async fn save_config(
+        &self,
+        server_config: &ServerConfig,
+        app_config: &Config,
+    ) -> Result<(), Error> {
         self.check_online()?;
 
         let mut state = self.state.write().unwrap();
         state.applied_config = Some(prosody_config_from_db(server_config.to_owned(), app_config));
         Ok(())
     }
-    fn reload(&self) -> Result<(), Error> {
+    async fn reload(&self) -> Result<(), Error> {
         self.check_online()?;
 
         let mut state = self.state.write().unwrap();
@@ -77,7 +82,7 @@ impl ServerCtlImpl for MockServerCtl {
         Ok(())
     }
 
-    fn add_user(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error> {
+    async fn add_user(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error> {
         self.check_online()?;
 
         let mut state = self.state.write().unwrap();
@@ -109,14 +114,14 @@ impl ServerCtlImpl for MockServerCtl {
         );
         Ok(())
     }
-    fn remove_user(&self, jid: &BareJid) -> Result<(), Error> {
+    async fn remove_user(&self, jid: &BareJid) -> Result<(), Error> {
         self.check_online()?;
 
         let mut state = self.state.write().unwrap();
         state.users.remove(jid);
         Ok(())
     }
-    fn set_user_role(&self, _jid: &BareJid, _role: &MemberRole) -> Result<(), Error> {
+    async fn set_user_role(&self, _jid: &BareJid, _role: &MemberRole) -> Result<(), Error> {
         self.check_online()?;
 
         // NOTE: The role is stored on our side in the database,

--- a/tests/prelude/mock_xmpp_service.rs
+++ b/tests/prelude/mock_xmpp_service.rs
@@ -103,26 +103,35 @@ impl MockXmppService {
     }
 }
 
+#[async_trait::async_trait]
 impl XmppServiceImpl for MockXmppService {
-    fn get_vcard(&self, _ctx: &XmppServiceContext, jid: &BareJid) -> Result<Option<VCard>, Error> {
+    async fn get_vcard(
+        &self,
+        _ctx: &XmppServiceContext,
+        jid: &BareJid,
+    ) -> Result<Option<VCard>, Error> {
         self.get_vcard(jid)
     }
-    fn set_own_vcard(&self, ctx: &XmppServiceContext, vcard: &VCard) -> Result<(), Error> {
+    async fn set_own_vcard(&self, ctx: &XmppServiceContext, vcard: &VCard) -> Result<(), Error> {
         self.set_vcard(&ctx.bare_jid, vcard)
     }
 
-    fn get_avatar(
+    async fn get_avatar(
         &self,
         _ctx: &XmppServiceContext,
         jid: &BareJid,
     ) -> Result<Option<AvatarData>, Error> {
         self.get_avatar(jid)
     }
-    fn set_own_avatar(&self, ctx: &XmppServiceContext, image_data: Vec<u8>) -> Result<(), Error> {
+    async fn set_own_avatar(
+        &self,
+        ctx: &XmppServiceContext,
+        image_data: Vec<u8>,
+    ) -> Result<(), Error> {
         self.set_avatar(&ctx.bare_jid, Some(image_data))
     }
 
-    fn is_connected(&self, _ctx: &XmppServiceContext, jid: &BareJid) -> Result<bool, Error> {
+    async fn is_connected(&self, _ctx: &XmppServiceContext, jid: &BareJid) -> Result<bool, Error> {
         self.is_connected(jid)
     }
 }


### PR DESCRIPTION
```rust
tokio::task::block_in_place(move || {
    Handle::current().block_on(async move {
        // ...
    })
})
```

was used in a lot of places, potentially causing thread blocks. By using `async_trait` we make sure no such issue will arise.