### PR TITLE
fix(tests): Fix behavior tests exit code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,6 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-# cucumber = "0.21"
 cucumber = { workspace = true, features = ["tracing"] }
 lazy_static = { workspace = true }
 linked-hash-map = { workspace = true }

--- a/tests/behavior.rs
+++ b/tests/behavior.rs
@@ -56,11 +56,6 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() {
-    // Run tests and ignore undefined steps
-    // TestWorld::run("tests/features").await;
-
-    // Run tests and ignore undefined steps, but show logs
-    // NOTE: Needs the "tracing" feature enabled for `cucumber`
     TestWorld::cucumber()
         // .init_tracing()
         .configure_and_init_tracing(
@@ -95,13 +90,10 @@ async fn main() {
                 )
             },
         )
-        .run("tests/features")
+        // Fail on undefined steps
+        // .fail_on_skipped()
+        .run_and_exit("tests/features")
         .await;
-
-    // Run and fail on undefined steps
-    // TestWorld::cucumber()
-    //     .fail_on_skipped()
-    //     .run_and_exit("tests/features").await;
 }
 
 fn test_rocket(


### PR DESCRIPTION
Even when steps failed, `cargo test --test behavior` would exit with code `0`… which means CI would still succeed with broken tests 😅