### PR TITLE
feat(error): Lower log level of most client errors (except "Forbidden"s)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,10 @@ impl Error {
             error!("{}", self.message);
         } else {
             // Client error
-            warn!("{}", self.message);
+            match self.code {
+                ErrorCode::Forbidden | ErrorCode::Unknown(_) => warn!("{}", self.message),
+                _ => info!("{}", self.message),
+            }
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,7 @@ impl ErrorCode {
 
 impl std::fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.value())
+        std::fmt::Display::fmt(self.value(), f)
     }
 }
 


### PR DESCRIPTION
Server errors (`500..<600`) have `ERROR` level, `Forbidden`s have `WARN` level and the rest have `INFO` level.

I also made sure errors cannot be logged twice. It did not resolve the fact that errors are logged 2 or 3 times in tests, I think there's a problem with how Cucumber and Rocket subscribe to logs and "relog" them.