### PR TITLE
feat: Rotate the API's XMPP password at launch

### DIFF
--- a/ADRs/2024-07-16-a-rotate-service-passwords.md
+++ b/ADRs/2024-07-16-a-rotate-service-passwords.md
@@ -1,0 +1,56 @@
+# ADR: Rotate service accounts passwords at every startup
+
+- Date: **2024-07-16**
+- Author: **Rémi Bardon <[remi@remibardon.name](mailto:remi@remibardon.name)>**
+<!-- Proposed|Accepted|Rejected, with date and channel if applicable -->
+- Status: **Accepted** via [#44](https://github.com/prose-im/prose-pod-api/pull/44) (2024-07-19)
+<!-- "ø" or a nested unordered list linking to other ADRs and their date -->
+- Relates to:
+  - [Store workspace data in a vCard](./2024-07-14-a-store-workspace-data-in-xmpp-vcard.md) (2024-07-14)
+<!-- "ø" or a nested unordered list linking to other ADRs and their date -->
+- Superseded by: ø
+<!-- "No" or "Yes" with the deprecation date -->
+- Deprecated: No
+
+## Context
+
+<!--
+This section describes the forces at play, including technological, political,
+social, and project local. These forces are probably in tension, and should be
+called out as such. The language in this section is value-neutral. It is simply
+describing facts.
+-->
+
+At the time of writing this ADR, the Prose Pod API needs two XMPP accounts to work properly. Those "service" accounts are made to be accessed only by the Prose Pod API and no other party should ever log into it.
+
+The first account is the "super admin" account, `prose-pod-api@admin.prose.org.local`, which is used to make administration changes to the Prose Pod Server (e.g. reloading the server configuration or creating users). Because it needs to exist before the Prose Pod API can even send a request to the Prose Pod Servern, this account is created automatically by the XMPP server when it starts, and the password must be known by both parties. We use environment variables to share this secret information, but a malicious Prosody plugin or just a bad code logging environment variables could expose critical credentials.
+
+The second account is the workspace account, `prose-workspace@<host>`, as detailed in [ADR: Store workspace data in a vCard](./2024-07-14-a-store-workspace-data-in-xmpp-vcard.md). This account is created by the Prose Pod API and has a random password. The Prose Pod API doesn't store the password anywhere, for obvious security reasons, therefore it cannot recover it after a restart. Since the "super admin" account can create XMPP users and change their passwords, a solution is to override the workspace account password with a new random one the Prose Pod API will once again store in memory.
+
+This ADR is there to document this decision but also generalize the process to the "super admin" account and every "service" account we will create in the future.
+
+## Decision
+
+<!--
+This section describes our response to these forces. It is stated in full
+sentences, with active voice. "We will …"
+-->
+
+To ensure no one can log into XMPP accounts made to be used only by the Prose Pod API (to prevent [privilege escalation]), we will rotate the passwords of "service" accounts every time the Prose Pod API starts. The "super admin" account password will become a "bootstrapping password", used for a few seconds to allow the Prose Pod API to send a first request to the Prose Pod Server. asking it to change its own password.
+
+By locking passwords access during this procedure, we *could* rotate all passwords more often if we feel the need. It's a very fast operation so we could transparently do it very often with virtually no impact for API users.
+
+## Consequences
+
+<!--
+This section describes the resulting context, after applying the decision.
+All consequences should be listed here, not just the "positive" ones.
+A particular decision may have positive, negative, and neutral consequences,
+but all of them affect the team and project in the future.
+-->
+
+Since passwords are random, not predefined nor stored, we won't be able to run two instances of the same Prose Pod API at the same time to scale horizontally. It's not something we plan on doing therefore this is not an issue.
+
+Other than that, the password rotation is completely transparent so apart from preventing unwanted access I don't see more consequences.
+
+[privilege escalation]: https://en.wikipedia.org/wiki/Privilege_escalation "Privilege escalation | Wikipedia"

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -20,6 +20,7 @@ as a template and replace every occurrence of `<TODO:Whatever>` by whatever it s
 - [Enrich member data in a separate HTTP API call](./2024-05-27-a-lazily-enriching-member-data.md) (2024-05-27)
 - [Use `prose-xmpp` and `mod_rest` to send stanzas to Prosody](./2024-06-05-a-prose-xmpp-and-mod_rest-to-send-stanzas.md) (2024-06-05)
 - [Store workspace data in a vCard](./2024-07-14-a-store-workspace-data-in-xmpp-vcard.md) (2024-07-14)
+- [Rotate service accounts passwords at every startup](./2024-07-16-a-rotate-service-passwords.md) (2024-07-16)
 
 ## Proposed ADRs
 

--- a/service/src/controllers/init_controller.rs
+++ b/service/src/controllers/init_controller.rs
@@ -9,10 +9,11 @@ use secrecy::SecretString;
 use crate::{
     config::AppConfig,
     entity::workspace,
-    model::{JidNode, Member, MemberRole, ServerConfig, ServiceSecretsStore, Workspace},
+    model::{JidNode, Member, MemberRole, ServerConfig, Workspace},
     repositories::{MemberRepository, ServerConfigCreateForm, WorkspaceRepository},
     services::{
         auth_service::AuthService,
+        secrets_store::SecretsStore,
         server_ctl::ServerCtl,
         server_manager::{self, CreateServiceAccountError, ServerManager},
         user_service::{UserCreateError, UserService},
@@ -33,7 +34,7 @@ impl<'r> InitController<'r> {
         server_ctl: &ServerCtl,
         app_config: &AppConfig,
         auth_service: &AuthService,
-        secrets_store: &ServiceSecretsStore,
+        secrets_store: &SecretsStore,
         server_config: impl Into<ServerConfigCreateForm>,
     ) -> Result<ServerConfig, InitServerConfigError> {
         // Initialize XMPP server configuration
@@ -83,7 +84,7 @@ impl<'r> InitController<'r> {
     pub async fn init_workspace(
         &self,
         app_config: &AppConfig,
-        secrets_store: &ServiceSecretsStore,
+        secrets_store: &SecretsStore,
         xmpp_service: &XmppServiceInner,
         server_config: &ServerConfig,
         form: impl Into<WorkspaceCreateForm>,

--- a/service/src/controllers/init_controller.rs
+++ b/service/src/controllers/init_controller.rs
@@ -3,25 +3,18 @@
 // Copyright: 2024, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use jid::BareJid;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use sea_orm::{DatabaseConnection, DbErr, NotSet, Set, TransactionTrait as _};
 use secrecy::SecretString;
-use tracing::debug;
 
 use crate::{
     config::AppConfig,
     entity::workspace,
-    model::{
-        JidDomain, JidNode, Member, MemberRole, ServerConfig, ServiceSecrets, ServiceSecretsStore,
-        Workspace,
-    },
+    model::{JidNode, Member, MemberRole, ServerConfig, ServiceSecretsStore, Workspace},
     repositories::{MemberRepository, ServerConfigCreateForm, WorkspaceRepository},
     services::{
-        auth_service::{self, AuthService},
-        jwt_service::{InvalidJwtClaimError, JWTError},
-        server_ctl::{self, ServerCtl},
-        server_manager::{self, ServerManager},
+        auth_service::AuthService,
+        server_ctl::ServerCtl,
+        server_manager::{self, CreateServiceAccountError, ServerManager},
         user_service::{UserCreateError, UserService},
         xmpp_service::XmppServiceInner,
     },
@@ -43,14 +36,14 @@ impl<'r> InitController<'r> {
         secrets_store: &ServiceSecretsStore,
         server_config: impl Into<ServerConfigCreateForm>,
     ) -> Result<ServerConfig, InitServerConfigError> {
-        // Create service XMPP accounts
+        // Initialize XMPP server configuration
         let server_config =
             ServerManager::init_server_config(self.db, server_ctl, app_config, server_config)
                 .await
                 .map_err(InitServerConfigError::CouldNotInitServerConfig)?;
 
         // Create service XMPP accounts
-        Self::create_service_accounts(
+        ServerManager::create_service_accounts(
             &server_config.domain,
             server_ctl,
             app_config,
@@ -61,62 +54,6 @@ impl<'r> InitController<'r> {
 
         Ok(server_config)
     }
-
-    pub async fn create_service_accounts(
-        domain: &JidDomain,
-        server_ctl: &ServerCtl,
-        app_config: &AppConfig,
-        auth_service: &AuthService,
-        secrets_store: &ServiceSecretsStore,
-    ) -> Result<(), CreateServiceAccountError> {
-        // Create workspace XMPP account
-        Self::create_service_account(
-            app_config.workspace_jid(domain),
-            server_ctl,
-            auth_service,
-            secrets_store,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    async fn create_service_account(
-        jid: BareJid,
-        server_ctl: &ServerCtl,
-        auth_service: &AuthService,
-        secrets_store: &ServiceSecretsStore,
-    ) -> Result<(), CreateServiceAccountError> {
-        debug!("Creating service account '{jid}'…");
-
-        // Generate a very strong random password
-        // NOTE: Code taken from <https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html#create-random-passwords-from-a-set-of-alphanumeric-characters>.
-        let password: SecretString = thread_rng()
-            .sample_iter(&Alphanumeric)
-            // 256 characters because why not
-            .take(256)
-            .map(char::from)
-            .collect::<String>()
-            .into();
-
-        // Create the XMPP user account
-        server_ctl.add_user(&jid, &password).await?;
-
-        // Log in as the service account (to get a JWT with access tokens)
-        let jwt = auth_service.log_in(&jid, &password).await?;
-        let jwt = auth_service.verify(&jwt)?;
-
-        // Read the access tokens from the JWT
-        let prosody_token = jwt
-            .prosody_token()
-            .map_err(CreateServiceAccountError::MissingProsodyToken)?;
-
-        // Store the secrets
-        let secrets = ServiceSecrets { prosody_token };
-        secrets_store.set_secrets(jid, secrets);
-
-        Ok(())
-    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -125,18 +62,6 @@ pub enum InitServerConfigError {
     CouldNotInitServerConfig(server_manager::Error),
     #[error("Could not create service XMPP account: {0}")]
     CouldNotCreateServiceAccount(#[from] CreateServiceAccountError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum CreateServiceAccountError {
-    #[error("Could not create XMPP account: {0}")]
-    CouldNotCreateXmppAccount(#[from] server_ctl::Error),
-    #[error("Could not log in: {0}")]
-    CouldNotLogIn(#[from] auth_service::Error),
-    #[error("The just-created JWT is invalid: {0}")]
-    InvalidJwt(#[from] JWTError),
-    #[error("The just-created JWT doesn't contain a Prosody token: {0}")]
-    MissingProsodyToken(InvalidJwtClaimError),
 }
 
 #[derive(Debug, Clone)]

--- a/service/src/controllers/workspace_controller.rs
+++ b/service/src/controllers/workspace_controller.rs
@@ -8,10 +8,13 @@ use sea_orm::{DatabaseConnection, DbErr, IntoActiveModel as _};
 
 use crate::{
     config::AppConfig,
-    model::{ServerConfig, ServiceSecretsStore, Workspace},
+    model::{ServerConfig, Workspace},
     repositories::WorkspaceRepository,
     sea_orm::{ActiveModelTrait as _, Set},
-    services::xmpp_service::{self, XmppService, XmppServiceContext, XmppServiceInner},
+    services::{
+        secrets_store::SecretsStore,
+        xmpp_service::{self, XmppService, XmppServiceContext, XmppServiceInner},
+    },
 };
 
 pub struct WorkspaceController<'r> {
@@ -25,11 +28,11 @@ impl<'r> WorkspaceController<'r> {
         xmpp_service: &'r XmppServiceInner,
         app_config: &'r AppConfig,
         server_config: &ServerConfig,
-        secrets_store: &'r ServiceSecretsStore,
+        secrets_store: &'r SecretsStore,
     ) -> Result<Self, WorkspaceControllerInitError> {
         let workspace_jid = app_config.workspace_jid(&server_config.domain);
         let prosody_token = secrets_store
-            .get_prosody_token(&workspace_jid)
+            .get_service_account_prosody_token(&workspace_jid)
             .ok_or(WorkspaceControllerInitError::WorkspaceXmppAccountNotInitialized)?;
         let ctx = XmppServiceContext {
             bare_jid: workspace_jid,

--- a/service/src/model/mod.rs
+++ b/service/src/model/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod invitations;
 mod jid;
 pub mod member_role;
 pub mod server_config;
-pub mod service_secrets_store;
 
 pub use durations::*;
 pub use email_address::*;
@@ -17,7 +16,6 @@ pub use invitations::*;
 pub use jid::*;
 pub use member_role::*;
 pub use server_config::*;
-pub use service_secrets_store::*;
 
 pub use crate::entity::{
     member::Model as Member, workspace::Model as Workspace,

--- a/service/src/model/service_secrets_store.rs
+++ b/service/src/model/service_secrets_store.rs
@@ -3,29 +3,65 @@
 // Copyright: 2024, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use std::{collections::HashMap, sync::RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use jid::BareJid;
 use secrecy::SecretString;
 
+use crate::config::AppConfig;
+
 /// A place to store service accounts secrets (e.g. Prosody tokens).
 ///
 /// WARN: This must NOT be used to save user tokens!
-#[derive(Default)]
+#[derive(Debug, Clone)]
 pub struct ServiceSecretsStore {
-    store: RwLock<HashMap<BareJid, ServiceSecrets>>,
+    store: Arc<RwLock<HashMap<BareJid, ServiceSecrets>>>,
+    // NOTE: This password is the only one to get a special treatment because of how
+    //   the Prose Pod API interacts with the Prose Pod Server.
+    prose_pod_api_xmpp_password: Arc<RwLock<SecretString>>,
 }
 
-#[derive(Clone)]
+impl ServiceSecretsStore {
+    pub fn from_config(app_config: &AppConfig) -> Self {
+        let prose_pod_api_xmpp_password = app_config.bootstrap.prose_pod_api_xmpp_password.as_ref().expect("App config is missing `bootstrap.prose_pod_api_xmpp_password`. You should define the `PROSE_BOOTSTRAP__PROSE_POD_API_XMPP_PASSWORD` environment variable.");
+
+        Self {
+            store: Arc::default(),
+            prose_pod_api_xmpp_password: Arc::new(RwLock::new(
+                prose_pod_api_xmpp_password.to_owned(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ServiceSecrets {
     pub prosody_token: SecretString,
 }
 
 impl ServiceSecretsStore {
+    pub fn set_prose_pod_api_xmpp_password(&self, password: SecretString) {
+        *self
+            .prose_pod_api_xmpp_password
+            .clone()
+            .write()
+            .expect("`prose_pod_api_xmpp_password` lock poisonned.") = password;
+    }
+
+    pub fn prose_pod_api_xmpp_password(&self) -> SecretString {
+        self.prose_pod_api_xmpp_password
+            .read()
+            .expect("`prose_pod_api_xmpp_password` lock poisonned.")
+            .to_owned()
+    }
+
     fn get_secrets(&self, jid: &BareJid) -> Option<ServiceSecrets> {
         self.store
             .read()
-            .expect("`CredentialsStore` lock poisonned.")
+            .expect("`ServiceSecretsStore` lock poisonned.")
             .get(jid)
             .cloned()
     }
@@ -33,7 +69,7 @@ impl ServiceSecretsStore {
     pub fn set_secrets(&self, jid: BareJid, secrets: ServiceSecrets) {
         self.store
             .write()
-            .expect("`CredentialsStore` lock poisonned.")
+            .expect("`ServiceSecretsStore` lock poisonned.")
             .insert(jid, secrets);
     }
 

--- a/service/src/prosody/prosody_admin_rest.rs
+++ b/service/src/prosody/prosody_admin_rest.rs
@@ -16,9 +16,10 @@ use tracing::trace;
 use super::{prosody_config_from_db, AsProsody as _};
 use crate::{
     config::Config,
-    model::{MemberRole, ServerConfig, ServiceSecretsStore},
+    model::{MemberRole, ServerConfig},
     services::{
         live_xmpp_service::NonStandardXmppClient,
+        secrets_store::SecretsStore,
         server_ctl::{Error, ServerCtlImpl},
     },
 };
@@ -34,14 +35,14 @@ pub struct ProsodyAdminRest {
     admin_rest_api_url: String,
     admin_rest_api_on_main_host_url: String,
     api_jid: BareJid,
-    secrets_store: ServiceSecretsStore,
+    secrets_store: SecretsStore,
 }
 
 impl ProsodyAdminRest {
     pub fn from_config(
         config: &Config,
         http_client: HttpClient,
-        secrets_store: ServiceSecretsStore,
+        secrets_store: SecretsStore,
     ) -> Self {
         Self {
             http_client,

--- a/service/src/prosody/prosody_admin_rest.rs
+++ b/service/src/prosody/prosody_admin_rest.rs
@@ -11,12 +11,12 @@ use reqwest::{
 };
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
-use tracing::debug;
+use tracing::trace;
 
 use super::{prosody_config_from_db, AsProsody as _};
 use crate::{
     config::Config,
-    model::{MemberRole, ServerConfig},
+    model::{MemberRole, ServerConfig, ServiceSecretsStore},
     services::{
         live_xmpp_service::NonStandardXmppClient,
         server_ctl::{Error, ServerCtlImpl},
@@ -33,23 +33,23 @@ pub struct ProsodyAdminRest {
     config_file_path: PathBuf,
     admin_rest_api_url: String,
     admin_rest_api_on_main_host_url: String,
-    api_auth_username: BareJid,
-    api_auth_password: SecretString,
+    api_jid: BareJid,
+    secrets_store: ServiceSecretsStore,
 }
 
 impl ProsodyAdminRest {
-    pub fn from_config(config: &Config, http_client: HttpClient) -> Self {
+    pub fn from_config(
+        config: &Config,
+        http_client: HttpClient,
+        secrets_store: ServiceSecretsStore,
+    ) -> Self {
         Self {
             http_client,
             config_file_path: config.server.prosody_config_file_path.to_owned(),
             admin_rest_api_url: config.server.admin_rest_api_url(),
             admin_rest_api_on_main_host_url: config.server.admin_rest_api_on_main_host_url(),
-            api_auth_username: config.api_jid(),
-            api_auth_password: config
-                .bootstrap
-                .prose_pod_api_xmpp_password
-                .to_owned()
-                .unwrap(),
+            api_jid: config.api_jid(),
+            secrets_store,
         }
     }
 
@@ -79,11 +79,15 @@ impl ProsodyAdminRest {
         let client = self.http_client.clone();
         let request = make_req(&client)
             .basic_auth(
-                self.api_auth_username.to_string(),
-                Some(self.api_auth_password.expose_secret()),
+                self.api_jid.to_string(),
+                Some(
+                    self.secrets_store
+                        .prose_pod_api_xmpp_password()
+                        .expose_secret(),
+                ),
             )
             .build()?;
-        debug!("Calling `{} {}`…", request.method(), request.url());
+        trace!("Calling `{} {}`…", request.method(), request.url());
 
         let (response, request_clone) = {
             let request_clone = request.try_clone();
@@ -97,7 +101,7 @@ impl ProsodyAdminRest {
         match map_res(response).await {
             Ok(res) => Ok(res),
             Err(response) => {
-                let mut err = "Prosody Admin REST API call failed.".to_owned();
+                let mut err = "Prosody Admin REST API returned an error.".to_owned();
                 if let Some(request) = request_clone {
                     err.push_str(&format!(
                         "\n  Request: {} {}\n  Request headers: {:?}\n  Request body: {:?}",
@@ -251,6 +255,19 @@ impl ServerCtlImpl for ProsodyAdminRest {
                     urlencoding::encode(&jid.to_string()),
                 ))
                 .body(format!(r#"{{"role":"{}"}}"#, role.as_prosody()))
+        })
+        .await
+        .map(|_| ())
+    }
+    async fn set_user_password(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error> {
+        self.call(|client| {
+            client
+                .patch(format!(
+                    "{}/{}/password",
+                    self.url("user"),
+                    urlencoding::encode(&jid.to_string())
+                ))
+                .body(format!(r#"{{"password":"{}"}}"#, password.expose_secret()))
         })
         .await
         .map(|_| ())

--- a/service/src/services/live_secrets_store.rs
+++ b/service/src/services/live_secrets_store.rs
@@ -11,20 +11,23 @@ use std::{
 use jid::BareJid;
 use secrecy::SecretString;
 
-use crate::config::AppConfig;
+use crate::{
+    config::AppConfig,
+    services::secrets_store::{SecretsStoreImpl, ServiceAccountSecrets},
+};
 
 /// A place to store service accounts secrets (e.g. Prosody tokens).
 ///
 /// WARN: This must NOT be used to save user tokens!
 #[derive(Debug, Clone)]
-pub struct ServiceSecretsStore {
-    store: Arc<RwLock<HashMap<BareJid, ServiceSecrets>>>,
+pub struct LiveSecretsStore {
+    store: Arc<RwLock<HashMap<BareJid, ServiceAccountSecrets>>>,
     // NOTE: This password is the only one to get a special treatment because of how
     //   the Prose Pod API interacts with the Prose Pod Server.
     prose_pod_api_xmpp_password: Arc<RwLock<SecretString>>,
 }
 
-impl ServiceSecretsStore {
+impl LiveSecretsStore {
     pub fn from_config(app_config: &AppConfig) -> Self {
         let prose_pod_api_xmpp_password = app_config.bootstrap.prose_pod_api_xmpp_password.as_ref().expect("App config is missing `bootstrap.prose_pod_api_xmpp_password`. You should define the `PROSE_BOOTSTRAP__PROSE_POD_API_XMPP_PASSWORD` environment variable.");
 
@@ -35,15 +38,18 @@ impl ServiceSecretsStore {
             )),
         }
     }
+
+    fn get_secrets(&self, jid: &BareJid) -> Option<ServiceAccountSecrets> {
+        self.store
+            .read()
+            .expect("`ServiceSecretsStore` lock poisonned.")
+            .get(jid)
+            .cloned()
+    }
 }
 
-#[derive(Debug, Clone)]
-pub struct ServiceSecrets {
-    pub prosody_token: SecretString,
-}
-
-impl ServiceSecretsStore {
-    pub fn set_prose_pod_api_xmpp_password(&self, password: SecretString) {
+impl SecretsStoreImpl for LiveSecretsStore {
+    fn set_prose_pod_api_xmpp_password(&self, password: SecretString) {
         *self
             .prose_pod_api_xmpp_password
             .clone()
@@ -51,29 +57,21 @@ impl ServiceSecretsStore {
             .expect("`prose_pod_api_xmpp_password` lock poisonned.") = password;
     }
 
-    pub fn prose_pod_api_xmpp_password(&self) -> SecretString {
+    fn prose_pod_api_xmpp_password(&self) -> SecretString {
         self.prose_pod_api_xmpp_password
             .read()
             .expect("`prose_pod_api_xmpp_password` lock poisonned.")
             .to_owned()
     }
 
-    fn get_secrets(&self, jid: &BareJid) -> Option<ServiceSecrets> {
-        self.store
-            .read()
-            .expect("`ServiceSecretsStore` lock poisonned.")
-            .get(jid)
-            .cloned()
-    }
-
-    pub fn set_secrets(&self, jid: BareJid, secrets: ServiceSecrets) {
+    fn set_service_account_secrets(&self, jid: BareJid, secrets: ServiceAccountSecrets) {
         self.store
             .write()
             .expect("`ServiceSecretsStore` lock poisonned.")
             .insert(jid, secrets);
     }
 
-    pub fn get_prosody_token(&self, jid: &BareJid) -> Option<SecretString> {
+    fn get_service_account_prosody_token(&self, jid: &BareJid) -> Option<SecretString> {
         self.get_secrets(jid).map(|c| c.prosody_token)
     }
 }

--- a/service/src/services/mod.rs
+++ b/service/src/services/mod.rs
@@ -6,8 +6,10 @@
 pub mod auth_service;
 pub mod invitation_service;
 pub mod jwt_service;
+pub mod live_secrets_store;
 pub(crate) mod live_xmpp_service;
 pub mod notifier;
+pub mod secrets_store;
 pub mod server_ctl;
 pub mod server_manager;
 pub mod user_service;

--- a/service/src/services/secrets_store.rs
+++ b/service/src/services/secrets_store.rs
@@ -1,0 +1,42 @@
+// prose-pod-api
+//
+// Copyright: 2024, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use std::{fmt::Debug, ops::Deref, sync::Arc};
+
+use jid::BareJid;
+use secrecy::SecretString;
+
+/// A place to store service accounts secrets (e.g. Prosody tokens).
+///
+/// WARN: This must NOT be used to save user tokens!
+#[derive(Debug, Clone)]
+pub struct SecretsStore(Arc<dyn SecretsStoreImpl>);
+
+impl SecretsStore {
+    pub fn new(implem: Arc<dyn SecretsStoreImpl>) -> Self {
+        Self(implem)
+    }
+}
+
+impl Deref for SecretsStore {
+    type Target = Arc<dyn SecretsStoreImpl>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceAccountSecrets {
+    pub prosody_token: SecretString,
+}
+
+pub trait SecretsStoreImpl: Debug + Sync + Send {
+    fn set_prose_pod_api_xmpp_password(&self, password: SecretString);
+    fn prose_pod_api_xmpp_password(&self) -> SecretString;
+
+    fn set_service_account_secrets(&self, jid: BareJid, secrets: ServiceAccountSecrets);
+    fn get_service_account_prosody_token(&self, jid: &BareJid) -> Option<SecretString>;
+}

--- a/service/src/services/server_ctl.rs
+++ b/service/src/services/server_ctl.rs
@@ -55,6 +55,7 @@ pub trait ServerCtlImpl: Debug + Sync + Send {
     async fn remove_user(&self, jid: &BareJid) -> Result<(), Error>;
 
     async fn set_user_role(&self, jid: &BareJid, role: &MemberRole) -> Result<(), Error>;
+    async fn set_user_password(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error>;
 
     /// Add a user to everyone's roster.
     async fn add_team_member(&self, jid: &BareJid) -> Result<(), Error>;

--- a/service/src/services/server_manager.rs
+++ b/service/src/services/server_manager.rs
@@ -237,6 +237,9 @@ impl<'r> ServerManager<'r> {
         auth_service: &AuthService,
         secrets_store: &ServiceSecretsStore,
     ) -> Result<(), CreateServiceAccountError> {
+        // NOTE: No need to create Prose Pod API's XMPP account as it's already created
+        //   automatically when the XMPP server starts (using `mod_init_admin` in Prosody).
+
         // Create workspace XMPP account
         Self::create_service_account(
             app_config.workspace_jid(domain),

--- a/service/src/services/server_manager.rs
+++ b/service/src/services/server_manager.rs
@@ -5,19 +5,29 @@
 
 use std::sync::{RwLock, RwLockWriteGuard};
 
+use jid::BareJid;
+use rand::{distributions::Alphanumeric, thread_rng, Rng as _};
 use sea_orm::IntoActiveModel;
-use tracing::trace;
+use secrecy::SecretString;
+use tracing::{debug, trace};
 
 use crate::{
     config::AppConfig,
     entity::server_config,
-    model::{DateLike, Duration, JidDomain, PossiblyInfinite, ServerConfig},
+    model::{
+        DateLike, Duration, JidDomain, PossiblyInfinite, ServerConfig, ServiceSecrets,
+        ServiceSecretsStore,
+    },
     repositories::{ServerConfigCreateForm, ServerConfigRepository},
     sea_orm::{ActiveModelTrait as _, DatabaseConnection, Set, TransactionTrait as _},
     services::server_ctl::ServerCtl,
 };
 
-use super::server_ctl;
+use super::{
+    auth_service::{self, AuthService},
+    jwt_service::{InvalidJwtClaimError, JWTError},
+    server_ctl::{self, ServerCtlError},
+};
 
 pub struct ServerManager<'r> {
     db: &'r DatabaseConnection,
@@ -101,6 +111,18 @@ impl<'r> ServerManager<'r> {
 
         Ok(())
     }
+
+    /// Generates a very strong random password.
+    fn strong_random_password() -> SecretString {
+        // NOTE: Code taken from <https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html#create-random-passwords-from-a-set-of-alphanumeric-characters>.
+        thread_rng()
+            .sample_iter(&Alphanumeric)
+            // 256 characters because why not
+            .take(256)
+            .map(char::from)
+            .collect::<String>()
+            .into()
+    }
 }
 
 impl<'r> ServerManager<'r> {
@@ -161,6 +183,20 @@ impl<'r> ServerManager<'r> {
         Ok(server_config)
     }
 
+    pub async fn rotate_api_xmpp_password(
+        server_ctl: &ServerCtl,
+        app_config: &AppConfig,
+        secrets_store: &ServiceSecretsStore,
+    ) -> Result<(), ServerCtlError> {
+        let api_jid = app_config.api_jid();
+        let password = Self::strong_random_password();
+
+        server_ctl.set_user_password(&api_jid, &password).await?;
+        secrets_store.set_prose_pod_api_xmpp_password(password);
+
+        Ok(())
+    }
+
     pub async fn set_domain(&self, domain: &JidDomain) -> Result<ServerConfig, Error> {
         trace!("Setting XMPP server domain to {domain}…");
         self.update(|active| {
@@ -191,6 +227,67 @@ impl<'r> ServerManager<'r> {
             .await?;
         Ok(model)
     }
+}
+
+impl<'r> ServerManager<'r> {
+    pub async fn create_service_accounts(
+        domain: &JidDomain,
+        server_ctl: &ServerCtl,
+        app_config: &AppConfig,
+        auth_service: &AuthService,
+        secrets_store: &ServiceSecretsStore,
+    ) -> Result<(), CreateServiceAccountError> {
+        // Create workspace XMPP account
+        Self::create_service_account(
+            app_config.workspace_jid(domain),
+            server_ctl,
+            auth_service,
+            secrets_store,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn create_service_account(
+        jid: BareJid,
+        server_ctl: &ServerCtl,
+        auth_service: &AuthService,
+        secrets_store: &ServiceSecretsStore,
+    ) -> Result<(), CreateServiceAccountError> {
+        debug!("Creating service account '{jid}'…");
+
+        // Create the XMPP user account
+        let password = Self::strong_random_password();
+        server_ctl.add_user(&jid, &password).await?;
+
+        // Log in as the service account (to get a JWT with access tokens)
+        let jwt = auth_service.log_in(&jid, &password).await?;
+        let jwt = auth_service.verify(&jwt)?;
+
+        // Read the access tokens from the JWT
+        let prosody_token = jwt
+            .prosody_token()
+            .map_err(CreateServiceAccountError::MissingProsodyToken)?;
+
+        // Store the secrets
+        let secrets = ServiceSecrets { prosody_token };
+        secrets_store.set_secrets(jid, secrets);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreateServiceAccountError {
+    #[error("Could not create XMPP account: {0}")]
+    CouldNotCreateXmppAccount(#[from] server_ctl::Error),
+    #[error("Could not log in: {0}")]
+    CouldNotLogIn(#[from] auth_service::Error),
+    #[error("The just-created JWT is invalid: {0}")]
+    InvalidJwt(#[from] JWTError),
+    #[error("The just-created JWT doesn't contain a Prosody token: {0}")]
+    MissingProsodyToken(InvalidJwtClaimError),
 }
 
 macro_rules! set_bool {

--- a/service/src/services/server_manager.rs
+++ b/service/src/services/server_manager.rs
@@ -126,30 +126,6 @@ impl<'r> ServerManager<'r> {
 }
 
 impl<'r> ServerManager<'r> {
-    // TODO: Use or delete the following comments
-
-    // pub fn add_admin(&self, jid: JID) {
-    //     todo!()
-    // }
-    // pub fn remove_admin(&self, jid: &JID) {
-    //     todo!()
-    // }
-
-    // pub fn set_rate_limit(&self, conn_type: ConnectionType, value: DataRate) {
-    //     todo!()
-    // }
-    // pub fn set_burst_limit(&self, conn_type: ConnectionType, value: Duration<TimeLike>) {
-    //     todo!()
-    // }
-    // /// Sets the time that an over-limit session is suspended for
-    // /// (`limits_resolution` in Prosody).
-    // ///
-    // /// See <https://prosody.im/doc/modules/mod_limits> for Prosody
-    // /// and <https://docs.ejabberd.im/admin/configuration/basic/#shapers> for ejabberd.
-    // pub fn set_timeout(&self, value: Duration<TimeLike>) {
-    //     todo!()
-    // }
-
     pub async fn init_server_config(
         db: &DatabaseConnection,
         server_ctl: &ServerCtl,

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use rocket::response::{self, Responder};
 use rocket::{Request, Response};
 use serde_json::json;
 use service::controllers::init_controller::{
-    CreateServiceAccountError, InitFirstAccountError, InitServerConfigError, InitWorkspaceError,
+    InitFirstAccountError, InitServerConfigError, InitWorkspaceError,
 };
 use service::controllers::invitation_controller::{
     InvitationAcceptError, InvitationCancelError, InvitationRejectError, InvitationResendError,
@@ -23,6 +23,7 @@ use service::controllers::workspace_controller::{
 };
 #[cfg(debug_assertions)]
 use service::services::jwt_service;
+use service::services::server_manager::CreateServiceAccountError;
 use service::services::{
     auth_service, invitation_service, notifier, server_ctl, server_manager,
     user_service::{self, UserCreateError},

--- a/src/guards/workspace_controller.rs
+++ b/src/guards/workspace_controller.rs
@@ -6,8 +6,8 @@
 use service::{
     config::AppConfig,
     controllers::workspace_controller::WorkspaceController,
-    model::{ServerConfig, ServiceSecretsStore},
-    services::xmpp_service::XmppServiceInner,
+    model::ServerConfig,
+    services::{secrets_store::SecretsStore, xmpp_service::XmppServiceInner},
 };
 
 use super::prelude::*;
@@ -21,7 +21,7 @@ impl<'r> LazyFromRequest<'r> for WorkspaceController<'r> {
         let xmpp_service = &try_outcome!(request_state!(req, XmppServiceInner));
         let app_config = &try_outcome!(request_state!(req, AppConfig));
         let server_config = try_outcome!(ServerConfig::from_request(req).await);
-        let secrets_store = &try_outcome!(request_state!(req, ServiceSecretsStore));
+        let secrets_store = &try_outcome!(request_state!(req, SecretsStore));
 
         match WorkspaceController::new(db, xmpp_service, app_config, &server_config, secrets_store)
         {

--- a/src/v1/init/routes.rs
+++ b/src/v1/init/routes.rs
@@ -8,9 +8,12 @@ use serde::{Deserialize, Serialize};
 use service::{
     config::AppConfig,
     controllers::init_controller::{InitController, InitFirstAccountForm, WorkspaceCreateForm},
-    model::{JidDomain, JidNode, ServerConfig, ServiceSecretsStore},
+    model::{JidDomain, JidNode, ServerConfig},
     repositories::ServerConfigCreateForm,
-    services::{auth_service::AuthService, server_ctl::ServerCtl, xmpp_service::XmppServiceInner},
+    services::{
+        auth_service::AuthService, secrets_store::SecretsStore, server_ctl::ServerCtl,
+        xmpp_service::XmppServiceInner,
+    },
 };
 
 use crate::{
@@ -50,7 +53,7 @@ impl Into<WorkspaceCreateForm> for InitWorkspaceRequest {
 pub async fn init_workspace<'r>(
     init_controller: LazyGuard<InitController<'r>>,
     app_config: &State<AppConfig>,
-    secrets_store: &State<ServiceSecretsStore>,
+    secrets_store: &State<SecretsStore>,
     xmpp_service: &State<XmppServiceInner>,
     server_config: LazyGuard<ServerConfig>,
     req: Json<InitWorkspaceRequest>,
@@ -99,7 +102,7 @@ pub async fn init_server_config<'r>(
     server_ctl: &State<ServerCtl>,
     app_config: &State<AppConfig>,
     auth_service: &State<AuthService>,
-    secrets_store: &State<ServiceSecretsStore>,
+    secrets_store: &State<SecretsStore>,
     req: Json<InitServerConfigRequest>,
 ) -> Created<ServerConfig> {
     let init_controller = init_controller.inner?;

--- a/tests/features/members-list.feature
+++ b/tests/features/members-list.feature
@@ -4,6 +4,7 @@ Feature: Members list
     Given the Prose Pod has been initialized
       And the XMPP server domain is <prose.org>
       And Valerian is an admin
+      And the Prose Pod API has started
 
   """
   In the Prose Pod Dashboard, admins should be able to see members.

--- a/tests/features/prose-pod-init.feature
+++ b/tests/features/prose-pod-init.feature
@@ -1,5 +1,8 @@
 Feature: Prose Pod initialization
 
+  Background:
+    Given the Prose Pod API has started
+
   Scenario: Initializing the workspace
     Given the server config has been initialized
       And the workspace has not been initialized

--- a/tests/features/rotating-service-passwords.feature
+++ b/tests/features/rotating-service-passwords.feature
@@ -1,0 +1,15 @@
+Feature: Rotating service account passwords
+
+  Rule: The "super admin" account password is rotated
+
+    Scenario: At API startup
+       When the Prose Pod API starts
+       Then <prose-pod-api@admin.prose.org.local>'s password is changed
+
+  Rule: The workspace account password is rotated
+
+    Scenario: At API startup
+      Given the Prose Pod has been initialized
+        And the XMPP server domain is <test.org>
+       When the Prose Pod API starts
+       Then <prose-workspace@test.org>'s password is changed

--- a/tests/features/server-config/file-upload.feature
+++ b/tests/features/server-config/file-upload.feature
@@ -2,6 +2,7 @@ Feature: XMPP server configuration: File upload
 
   Background:
     Given the Prose Pod has been initialized
+      And the Prose Pod API has started
 
   Rule: File uploading can be turned on and off
 

--- a/tests/features/server-config/message-archive.feature
+++ b/tests/features/server-config/message-archive.feature
@@ -2,6 +2,7 @@ Feature: XMPP server configuration: Message archive
 
   Background:
     Given the Prose Pod has been initialized
+      And the Prose Pod API has started
 
   Rule: Message archiving can be turned on and off
 

--- a/tests/features/workspace-icon.feature
+++ b/tests/features/workspace-icon.feature
@@ -1,5 +1,8 @@
 Feature: Workspace icon
 
+  Background:
+    Given the Prose Pod API has started
+
   Rule: The API should warn if the workspace has not been initialized when getting the workspace icon
 
     Scenario: XMPP server and workspace not initialized

--- a/tests/features/workspace-invitation.feature
+++ b/tests/features/workspace-invitation.feature
@@ -3,6 +3,7 @@ Feature: Inviting members
   Background:
     Given the Prose Pod has been initialized
       And the XMPP server domain is <prose.org>
+      And the Prose Pod API has started
 
   """
   The intended way of inviting a new member to a Prose server

--- a/tests/features/workspace-name.feature
+++ b/tests/features/workspace-name.feature
@@ -1,5 +1,8 @@
 Feature: Workspace name
 
+  Background:
+    Given the Prose Pod API has started
+
   Rule: The API should warn if the workspace has not been initialized when getting the workspace name
 
     Scenario: XMPP server and workspace not initialized

--- a/tests/prelude/mock_auth_service.rs
+++ b/tests/prelude/mock_auth_service.rs
@@ -17,7 +17,7 @@ use crate::mock_server_ctl::MockServerCtlState;
 
 #[derive(Debug, Clone)]
 pub struct MockAuthService {
-    jwt_service: JWTService,
+    pub(crate) jwt_service: JWTService,
     pub(crate) state: Arc<RwLock<MockAuthServiceState>>,
     pub mock_server_ctl_state: Arc<RwLock<MockServerCtlState>>,
 }

--- a/tests/prelude/mock_notifier.rs
+++ b/tests/prelude/mock_notifier.rs
@@ -19,12 +19,6 @@ pub struct MockNotifierState {
     pub sent: Vec<Notification>,
 }
 
-impl MockNotifier {
-    pub fn new(state: Arc<RwLock<MockNotifierState>>) -> Self {
-        Self { state }
-    }
-}
-
 impl GenericNotifier for MockNotifier {
     fn name(&self) -> &'static str {
         "dummy_notifier"

--- a/tests/prelude/mock_secrets_store.rs
+++ b/tests/prelude/mock_secrets_store.rs
@@ -1,0 +1,85 @@
+// prose-pod-api
+//
+// Copyright: 2024, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, RwLock, RwLockWriteGuard},
+};
+
+use secrecy::SecretString;
+use service::{
+    config::AppConfig,
+    services::{
+        live_secrets_store::LiveSecretsStore,
+        secrets_store::{SecretsStoreImpl, ServiceAccountSecrets},
+    },
+    xmpp_parsers::jid::BareJid,
+};
+
+#[derive(Debug, Clone)]
+pub struct MockSecretsStore {
+    implem: LiveSecretsStore,
+    state: Arc<RwLock<MockSecretsStoreState>>,
+    api_jid: BareJid,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MockSecretsStoreState {
+    pub changes_count: HashMap<BareJid, u32>,
+}
+
+impl MockSecretsStore {
+    pub fn new(implem: LiveSecretsStore, app_config: &AppConfig) -> Self {
+        Self {
+            implem,
+            state: Default::default(),
+            api_jid: app_config.api_jid(),
+        }
+    }
+
+    pub(crate) fn state(&self) -> MockSecretsStoreState {
+        self.state
+            .read()
+            .expect("`MockSecretsStoreState` lock poisonned.")
+            .clone()
+    }
+
+    pub(crate) fn state_mut(&self) -> RwLockWriteGuard<MockSecretsStoreState> {
+        self.state
+            .write()
+            .expect("`MockSecretsStoreState` lock poisonned.")
+    }
+
+    pub fn changes_count(&self, jid: &BareJid) -> u32 {
+        self.state().changes_count.get(jid).cloned().unwrap_or(0)
+    }
+}
+
+impl SecretsStoreImpl for MockSecretsStore {
+    fn set_prose_pod_api_xmpp_password(&self, password: SecretString) {
+        *self
+            .state_mut()
+            .changes_count
+            .entry(self.api_jid.clone())
+            .or_insert(0) += 1;
+        self.implem.set_prose_pod_api_xmpp_password(password)
+    }
+    fn prose_pod_api_xmpp_password(&self) -> SecretString {
+        self.implem.prose_pod_api_xmpp_password()
+    }
+
+    fn set_service_account_secrets(&self, jid: BareJid, secrets: ServiceAccountSecrets) {
+        *self
+            .state_mut()
+            .changes_count
+            .entry(jid.clone())
+            .or_insert(0) += 1;
+        self.implem.set_service_account_secrets(jid, secrets)
+    }
+    fn get_service_account_prosody_token(&self, jid: &BareJid) -> Option<SecretString> {
+        self.implem.get_service_account_prosody_token(jid)
+    }
+}

--- a/tests/prelude/mock_server_ctl.rs
+++ b/tests/prelude/mock_server_ctl.rs
@@ -24,7 +24,6 @@ pub struct MockServerCtl {
 
 #[derive(Debug, Clone)]
 pub struct UserAccount {
-    pub jid: BareJid,
     pub password: SecretString,
 }
 
@@ -109,7 +108,6 @@ impl ServerCtlImpl for MockServerCtl {
         state.users.insert(
             jid.clone(),
             UserAccount {
-                jid: jid.clone(),
                 password: password.to_owned(),
             },
         );

--- a/tests/prelude/mock_server_ctl.rs
+++ b/tests/prelude/mock_server_ctl.rs
@@ -90,17 +90,18 @@ impl ServerCtlImpl for MockServerCtl {
         // Check that the domain exists in the Prosody configuration. If it's not the case,
         // Prosody won't add the user. This happens if the server config wasn't initialized
         // and Prosody wasn't reloaded with a full configuration.
-        let domain_exists = state.applied_config.as_ref().is_some_and(|config| {
-            config
-                .additional_sections
-                .iter()
-                .any(|section| match section {
-                    ProsodyConfigSection::VirtualHost { hostname, .. } => {
-                        hostname == &jid.domain().to_string()
-                    }
-                    _ => false,
-                })
-        });
+        let domain_exists = jid.domain().as_str() == "admin.prose.org.local"
+            || state.applied_config.as_ref().is_some_and(|config| {
+                config
+                    .additional_sections
+                    .iter()
+                    .any(|section| match section {
+                        ProsodyConfigSection::VirtualHost { hostname, .. } => {
+                            hostname == &jid.domain().to_string()
+                        }
+                        _ => false,
+                    })
+            });
         if !domain_exists {
             return Err(Error::Other(format!("Domain {} not declared in the Prosody configuration. You might need to initialize the server configuration.", jid.domain())));
         }
@@ -129,12 +130,30 @@ impl ServerCtlImpl for MockServerCtl {
         //   our `DummyServerCtl` has nothing to save.
         Ok(())
     }
+    async fn set_user_password(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error> {
+        self.check_online()?;
+
+        let mut state = self.state.write().unwrap();
+        state
+            .users
+            .get_mut(jid)
+            .expect(&format!(
+                "`MockServerCtl` cannot set <{jid}>'s password: User must be created first."
+            ))
+            .password = password.to_owned();
+
+        Ok(())
+    }
 
     async fn add_team_member(&self, _jid: &BareJid) -> Result<(), Error> {
+        self.check_online()?;
+
         // We don't care in tests for now
         Ok(())
     }
     async fn remove_team_member(&self, _jid: &BareJid) -> Result<(), Error> {
+        self.check_online()?;
+
         // We don't care in tests for now
         Ok(())
     }

--- a/tests/prelude/mock_xmpp_service.rs
+++ b/tests/prelude/mock_xmpp_service.rs
@@ -28,10 +28,6 @@ pub struct MockXmppServiceState {
 }
 
 impl MockXmppService {
-    pub fn new(state: Arc<RwLock<MockXmppServiceState>>) -> Self {
-        Self { state }
-    }
-
     fn check_online(&self) -> Result<(), Error> {
         if self.state.read().unwrap().online {
             Ok(())

--- a/tests/prelude/mod.rs
+++ b/tests/prelude/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod mock_auth_service;
 pub mod mock_notifier;
+pub mod mock_secrets_store;
 pub mod mock_server_ctl;
 pub mod mock_xmpp_service;
 pub mod notifier;

--- a/tests/prelude/notifier.rs
+++ b/tests/prelude/notifier.rs
@@ -16,6 +16,6 @@ fn then_n_emails_sent(world: &mut TestWorld, n: usize) {
 
 #[then(expr = "the email body should match {string}")]
 fn then_email_matches(world: &mut TestWorld, pattern: Regex) {
-    let email = notification_message(&world.config.branding, &world.notifier_state().sent[0]);
+    let email = notification_message(&world.app_config.branding, &world.notifier_state().sent[0]);
     assert!(pattern.is_match(&email));
 }

--- a/tests/v1/init.rs
+++ b/tests/v1/init.rs
@@ -52,9 +52,9 @@ async fn given_workspace_initialized(world: &mut TestWorld) -> Result<(), Error>
     world
         .init_controller()
         .init_workspace(
-            &world.config,
-            world.secrets_store(),
-            &world.xmpp_service(),
+            &world.app_config,
+            &world.secrets_store,
+            &world.xmpp_service,
             &world.server_config().await?,
             form,
         )
@@ -77,10 +77,10 @@ async fn given_server_config_initialized(world: &mut TestWorld) -> Result<(), Er
     world
         .init_controller()
         .init_server_config(
-            &world.server_ctl(),
-            &world.config,
-            &world.auth_service(),
-            world.secrets_store(),
+            &world.server_ctl,
+            &world.app_config,
+            &world.auth_service,
+            &world.secrets_store,
             form,
         )
         .await?;
@@ -144,19 +144,19 @@ async fn init_first_account<'a>(
 
 #[when(expr = "someone initializes a workspace named {string}")]
 async fn when_init_workspace(world: &mut TestWorld, name: String) {
-    let res = init_workspace(&world.client, &name).await;
+    let res = init_workspace(world.client(), &name).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "someone initializes the server at <{text}>")]
 async fn when_init_server_config(world: &mut TestWorld, domain: Text) {
-    let res = init_server_config(&world.client, &domain).await;
+    let res = init_server_config(world.client(), &domain).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "someone creates the first account {string} with node {string}")]
 async fn when_init_first_account(world: &mut TestWorld, nickname: String, node: JidNode) {
-    let res = init_first_account(&world.client, &node, &nickname).await;
+    let res = init_first_account(world.client(), &node, &nickname).await;
     world.result = Some(res.into());
 }
 

--- a/tests/v1/invitations/mod.rs
+++ b/tests/v1/invitations/mod.rs
@@ -184,7 +184,7 @@ async fn given_invited(world: &mut TestWorld, email_address: EmailAddress) -> Re
             },
             created_at: None,
         },
-        world.uuid_gen(),
+        &world.uuid_gen,
     )
     .await?;
 
@@ -230,7 +230,7 @@ async fn given_n_invited(world: &mut TestWorld, n: u32) -> Result<(), Error> {
                 },
                 created_at: None,
             },
-            world.uuid_gen(),
+            &world.uuid_gen,
         )
         .await?;
         world.workspace_invitations.insert(email_address, model);
@@ -264,7 +264,7 @@ async fn given_invitation_resent(world: &mut TestWorld) -> Result<(), MutationEr
 
     // Resend invitation
     let db = world.db();
-    let model = InvitationRepository::resend(db, world.uuid_gen(), invitation_before).await?;
+    let model = InvitationRepository::resend(db, &world.uuid_gen, invitation_before).await?;
 
     // Store current invitation data
     world
@@ -317,7 +317,7 @@ async fn when_inviting(
     let token = world.token(name.0);
     let email_address = email_address.0;
     let res = invite_member(
-        &world.client,
+        world.client(),
         &token,
         &JidNode::from(email_address.to_owned()),
         pre_assigned_role,
@@ -330,7 +330,7 @@ async fn when_inviting(
 #[when(expr = "{text} lists pending invitations")]
 async fn when_listing_workspace_invitations(world: &mut TestWorld, name: Text) {
     let token = world.token(name.0);
-    let res = list_workspace_invitations(&world.client, token).await;
+    let res = list_workspace_invitations(world.client(), token).await;
     world.result = Some(res.into());
 }
 
@@ -341,7 +341,7 @@ async fn when_listing_workspace_invitations_paged(
     page_size: u64,
 ) {
     let token = world.token(name.0);
-    let res = list_workspace_invitations_paged(&world.client, token, 1, page_size).await;
+    let res = list_workspace_invitations_paged(world.client(), token, 1, page_size).await;
     world.result = Some(res.into());
 }
 
@@ -353,7 +353,7 @@ async fn when_getting_workspace_invitations_page(
     page_size: u64,
 ) {
     let token = world.token(name.0);
-    let res = list_workspace_invitations_paged(&world.client, token, page_number, page_size).await;
+    let res = list_workspace_invitations_paged(world.client(), token, page_number, page_size).await;
     world.result = Some(res.into());
 }
 
@@ -364,7 +364,7 @@ async fn when_getting_workspace_invitation_for_accept_token(
 ) {
     let invitation = world.workspace_invitation(&email_address);
     let res = get_workspace_invitation_by_token(
-        &world.client,
+        world.client(),
         &invitation.accept_token,
         TokenType::Accept,
     )
@@ -379,7 +379,7 @@ async fn when_getting_workspace_invitation_for_reject_token(
 ) {
     let invitation = world.workspace_invitation(&email_address);
     let res = get_workspace_invitation_by_token(
-        &world.client,
+        world.client(),
         &invitation.reject_token,
         TokenType::Reject,
     )
@@ -393,7 +393,7 @@ async fn when_getting_workspace_invitation_for_previous_accept_token(
     email_address: EmailAddress,
 ) {
     let res = get_workspace_invitation_by_token(
-        &world.client,
+        world.client(),
         &world.previous_workspace_invitation_accept_token(&email_address),
         TokenType::Accept,
     )
@@ -405,7 +405,7 @@ async fn when_getting_workspace_invitation_for_previous_accept_token(
 async fn when_invited_accepts_invitation(world: &mut TestWorld, email_address: EmailAddress) {
     let invitation = world.workspace_invitation(&email_address.0);
     let res = accept_workspace_invitation(
-        &world.client,
+        world.client(),
         invitation.accept_token,
         email_address.0.local_part().to_string(),
         None,
@@ -422,14 +422,14 @@ async fn when_invited_accepts_invitation_with_nickname(
 ) {
     let invitation = world.workspace_invitation(&email_address.0);
     let res =
-        accept_workspace_invitation(&world.client, invitation.accept_token, nickname, None).await;
+        accept_workspace_invitation(world.client(), invitation.accept_token, nickname, None).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "<{email}> uses the previous invitation accept link they received")]
 async fn when_invited_uses_old_accept_link(world: &mut TestWorld, email_address: EmailAddress) {
     let res = accept_workspace_invitation(
-        &world.client,
+        world.client(),
         world.previous_workspace_invitation_accept_token(&email_address),
         email_address.0.local_part().to_string(),
         None,
@@ -441,7 +441,7 @@ async fn when_invited_uses_old_accept_link(world: &mut TestWorld, email_address:
 #[when(expr = "<{email}> rejects their invitation")]
 async fn when_invited_rejects_invitation(world: &mut TestWorld, email_address: EmailAddress) {
     let invitation = world.workspace_invitation(&email_address.0);
-    let res = reject_workspace_invitation(&world.client, invitation.reject_token).await;
+    let res = reject_workspace_invitation(world.client(), invitation.reject_token).await;
     world.result = Some(res.into());
 }
 
@@ -450,7 +450,7 @@ async fn when_user_resends_workspace_invitation(world: &mut TestWorld, name: Tex
     let token = world.token(name.0);
     let invitation = world.scenario_workspace_invitation().1;
     let res =
-        workspace_invitation_admin_action(&world.client, token, invitation.id, "resend").await;
+        workspace_invitation_admin_action(world.client(), token, invitation.id, "resend").await;
     world.result = Some(res.into());
 }
 
@@ -458,7 +458,7 @@ async fn when_user_resends_workspace_invitation(world: &mut TestWorld, name: Tex
 async fn when_user_cancels_workspace_invitation(world: &mut TestWorld, name: Text) {
     let token = world.token(name.0);
     let invitation = world.scenario_workspace_invitation().1;
-    let res = cancel_workspace_invitation(&world.client, token, invitation.id).await;
+    let res = cancel_workspace_invitation(world.client(), token, invitation.id).await;
     world.result = Some(res.into());
 }
 

--- a/tests/v1/members/mod.rs
+++ b/tests/v1/members/mod.rs
@@ -103,7 +103,7 @@ async fn given_n_members(world: &mut TestWorld, n: u64) -> Result<(), Error> {
             joined_at: None,
         };
         let model = MemberRepository::create(db, member).await?;
-        let token = world.auth_service.log_in_unchecked(&jid)?;
+        let token = world.mock_auth_service.log_in_unchecked(&jid)?;
 
         world.members.insert(jid.to_string(), (model, token));
     }
@@ -113,26 +113,26 @@ async fn given_n_members(world: &mut TestWorld, n: u64) -> Result<(), Error> {
 #[when(expr = "{word} lists members")]
 async fn when_listing_members(world: &mut TestWorld, name: String) {
     let token = world.token(name);
-    let res = list_members(&world.client, token).await;
+    let res = list_members(world.client(), token).await;
     world.result = Some(res.into());
 }
 
 #[when("someone lists members without authenticating")]
 async fn when_listing_members_unauthenticated(world: &mut TestWorld) {
-    let res = list_members_(&world.client, None).await;
+    let res = list_members_(world.client(), None).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "someone lists members using {string} as Bearer token")]
 async fn when_listing_members_custom_token(world: &mut TestWorld, token: String) {
-    let res = list_members(&world.client, token.into()).await;
+    let res = list_members(world.client(), token.into()).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "{word} lists members by pages of {int}")]
 async fn when_listing_members_paged(world: &mut TestWorld, name: String, page_size: u64) {
     let token = world.token(name);
-    let res = list_members_paged(&world.client, token, 1, page_size).await;
+    let res = list_members_paged(world.client(), token, 1, page_size).await;
     world.result = Some(res.into());
 }
 
@@ -144,7 +144,7 @@ async fn when_getting_members_page(
     page_size: u64,
 ) {
     let token = world.token(name);
-    let res = list_members_paged(&world.client, token, page_number, page_size).await;
+    let res = list_members_paged(world.client(), token, page_number, page_size).await;
     world.result = Some(res.into());
 }
 
@@ -155,7 +155,7 @@ async fn when_getting_members_details(world: &mut TestWorld, name: String, names
     for name in names.iter() {
         jids.push(name_to_jid(world, name).await.unwrap());
     }
-    let res = enrich_members(&world.client, token, jids).await;
+    let res = enrich_members(world.client(), token, jids).await;
     world.result = Some(res.into());
 }
 
@@ -182,7 +182,7 @@ async fn then_nickname(
     nickname: String,
 ) -> Result<(), xmpp_service::Error> {
     let vcard = world
-        .xmpp_service
+        .mock_xmpp_service
         .get_vcard(&jid)?
         .expect("vCard not found");
 

--- a/tests/v1/mod.rs
+++ b/tests/v1/mod.rs
@@ -40,7 +40,7 @@ async fn given_admin(world: &mut TestWorld, name: String) -> Result<(), Error> {
     };
     let model = MemberRepository::create(db, member).await?;
 
-    let token = world.auth_service.log_in_unchecked(&jid)?;
+    let token = world.mock_auth_service.log_in_unchecked(&jid)?;
 
     world.members.insert(name, (model, token));
 
@@ -59,7 +59,7 @@ async fn given_not_admin(world: &mut TestWorld, name: String) -> Result<(), Erro
     };
     let model = MemberRepository::create(db, member).await?;
 
-    let token = world.auth_service.log_in_unchecked(&jid)?;
+    let token = world.mock_auth_service.log_in_unchecked(&jid)?;
 
     world.members.insert(name, (model, token));
 
@@ -89,7 +89,7 @@ async fn given_presence(
 async fn given_avatar(world: &mut TestWorld, name: String, avatar: String) -> Result<(), Error> {
     let jid = name_to_jid(world, &name).await?;
     world
-        .xmpp_service
+        .mock_xmpp_service
         .set_avatar(&jid, Some(AvatarData::Base64(avatar)))?;
     Ok(())
 }
@@ -97,7 +97,7 @@ async fn given_avatar(world: &mut TestWorld, name: String, avatar: String) -> Re
 #[given(expr = "{} has no avatar")]
 async fn given_no_avatar(world: &mut TestWorld, name: String) -> Result<(), Error> {
     let jid = name_to_jid(world, &name).await?;
-    world.xmpp_service.set_avatar(&jid, None)?;
+    world.mock_xmpp_service.set_avatar(&jid, None)?;
     Ok(())
 }
 

--- a/tests/v1/server/config.rs
+++ b/tests/v1/server/config.rs
@@ -68,7 +68,7 @@ async fn given_server_config(
         &mut <<server_config::Model as ModelTrait>::Entity as EntityTrait>::ActiveModel,
     ) -> (),
 ) -> Result<(), Error> {
-    let app_config = &world.config;
+    let app_config = &world.app_config;
 
     let mut server_config = world.server_config_model().await?.into_active_model();
     update(&mut server_config);
@@ -142,7 +142,7 @@ async fn given_message_archive_retention(
 #[when(expr = "{} turns message archiving {toggle}")]
 async fn when_set_message_archiving(world: &mut TestWorld, name: String, state: ToggleState) {
     let token = user_token!(world, name);
-    let res = set_message_archiving(&world.client, token, state.into()).await;
+    let res = set_message_archiving(world.client(), token, state.into()).await;
     world.result = Some(res.into());
 }
 
@@ -153,21 +153,21 @@ async fn when_set_message_archive_retention(
     duration: Duration,
 ) {
     let token = user_token!(world, name);
-    let res = set_message_archive_retention(&world.client, token, duration.into()).await;
+    let res = set_message_archive_retention(world.client(), token, duration.into()).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "{} resets the Messaging configuration to its default value")]
 async fn when_reset_messaging_configuration(world: &mut TestWorld, name: String) {
     let token = user_token!(world, name);
-    let res = reset_messaging_configuration(&world.client, token).await;
+    let res = reset_messaging_configuration(world.client(), token).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "{} resets the message archive retention to its default value")]
 async fn when_reset_message_archive_retention(world: &mut TestWorld, name: String) {
     let token = user_token!(world, name);
-    let res = reset_message_archive_retention(&world.client, token).await;
+    let res = reset_message_archive_retention(world.client(), token).await;
     world.result = Some(res.into());
 }
 
@@ -262,21 +262,21 @@ async fn given_file_retention(world: &mut TestWorld, duration: Duration) -> Resu
 #[when(expr = "{} turns file uploading {toggle}")]
 async fn when_set_file_uploading(world: &mut TestWorld, name: String, state: ToggleState) {
     let token = user_token!(world, name);
-    let res = set_file_uploading(&world.client, token, state.into()).await;
+    let res = set_file_uploading(world.client(), token, state.into()).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "{} resets the Files configuration to its default value")]
 async fn when_reset_files_configuration(world: &mut TestWorld, name: String) {
     let token = user_token!(world, name);
-    let res = reset_files_configuration(&world.client, token).await;
+    let res = reset_files_configuration(world.client(), token).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "{} sets the file retention to {duration}")]
 async fn when_set_file_retention(world: &mut TestWorld, name: String, duration: Duration) {
     let token = user_token!(world, name);
-    let res = set_file_retention(&world.client, token, duration.into()).await;
+    let res = set_file_retention(world.client(), token, duration.into()).await;
     world.result = Some(res.into());
 }
 

--- a/tests/v1/workspace/mod.rs
+++ b/tests/v1/workspace/mod.rs
@@ -44,13 +44,13 @@ async fn given_workspace_name(world: &mut TestWorld, name: String) -> Result<(),
 
 #[when("a user gets the workspace name")]
 async fn when_user_gets_workspace_name(world: &mut TestWorld) {
-    let res = get_workspace_name(&world.client).await;
+    let res = get_workspace_name(world.client()).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "a user sets the workspace name to {string}")]
 async fn when_set_workspace_name(world: &mut TestWorld, name: String) {
-    let res = set_workspace_name(&world.client, &name).await;
+    let res = set_workspace_name(world.client(), &name).await;
     world.result = Some(res.into());
 }
 
@@ -93,8 +93,8 @@ async fn set_workspace_icon<'a>(client: &'a Client, png_data: String) -> LocalRe
 #[given(expr = "the workspace icon is {string}")]
 async fn given_workspace_icon_url(world: &mut TestWorld, png_data: String) -> Result<(), Error> {
     let server_config = world.server_config().await?;
-    world.xmpp_service.set_avatar(
-        &world.config.workspace_jid(&server_config.domain),
+    world.mock_xmpp_service.set_avatar(
+        &world.app_config.workspace_jid(&server_config.domain),
         Some(AvatarData::Base64(png_data)),
     )?;
     Ok(())
@@ -102,13 +102,13 @@ async fn given_workspace_icon_url(world: &mut TestWorld, png_data: String) -> Re
 
 #[when("a user gets the workspace icon")]
 async fn when_user_gets_workspace_icon(world: &mut TestWorld) {
-    let res = get_workspace_icon(&world.client).await;
+    let res = get_workspace_icon(world.client()).await;
     world.result = Some(res.into());
 }
 
 #[when(expr = "a user sets the workspace icon to {string}")]
 async fn when_set_workspace_icon_url(world: &mut TestWorld, png_data: String) {
-    let res = set_workspace_icon(&world.client, png_data).await;
+    let res = set_workspace_icon(world.client(), png_data).await;
     world.result = Some(res.into());
 }
 


### PR DESCRIPTION
- [x] ADR about rotating passwords
- [x] Smoke tests
- [x] Integration tests (already implicitly covered)

TL;DR:

- The API's XMPP password is saved in `ServiceSecretsStore`
  - Initialized with `app_config.bootstrap.prose_pod_api_xmpp_password`
  - Nice error saying you should define `PROSE_BOOTSTRAP__PROSE_POD_API_XMPP_PASSWORD` if missing
- Like all service accounts, the API's XMPP password is a 256 characters random alphanumeric string