### PR TITLE
fix: Fix `task open-api-docs-ui`

### DIFF
--- a/crates/api/tests/integration/.gitignore
+++ b/crates/api/tests/integration/.gitignore
@@ -1,0 +1,1 @@
+!in-memory.env

--- a/scripts/open-api-docs-ui
+++ b/scripts/open-api-docs-ui
@@ -18,4 +18,5 @@ warn "Because the Prose Pod API cannot be started alone, this script uses the 
 
 ENV_FILE="${PROSE_POD_API_DIR:?}"/crates/api/tests/integration/in-memory.env \
 	SERVER_ROOT="${PROSE_POD_SYSTEM_DIR:?}"/server/pod \
+	PROSE_CONFIG_FILE="${PROSE_POD_API_DIR:?}"/crates/api/tests/integration/Prose-test.toml \
 	docker compose -f "${PROSE_POD_SYSTEM_DIR:?}"/compose.yaml up


### PR DESCRIPTION
Because `prose-pod-system` does not contain a `Prose.toml` file anymore, `task open-api-docs-ui` was failing saying `Could not read config`.

It's now fixed.

I also fixed the fact that `in-memory.env` was unintentionally ignored by git.