### PR TITLE
chore: Improve how errors are returned in debug builds

### DIFF
--- a/Prose.toml
+++ b/Prose.toml
@@ -8,8 +8,6 @@
 page_url = "https://admin.prose.org/"
 company_name = "Prose"
 
-[notify]
-
 [notify.email]
 from = "pod@prose.org"
 to = "pod@prose.org"

--- a/Prose.toml
+++ b/Prose.toml
@@ -1,18 +1,16 @@
 # Prose Pod API
 # REST API for administrating a Prose Pod
 # Configuration file
-# Example: https://github.com/prose-im/prose-pod-api/blob/master/Prose.toml
+# Example: https://github.com/prose-im/prose-pod-system/blob/master/Prose-example.toml
+# All keys: https://github.com/prose-im/prose-pod-api/blob/master/crates/service/src/features/app_config/mod.rs
 
 [branding]
-
-page_title = "Prose Pod API"
 page_url = "https://admin.prose.org/"
 company_name = "Prose"
 
 [notify]
 
 [notify.email]
-
 from = "pod@prose.org"
 to = "pod@prose.org"
 

--- a/crates/rest-api/src/error/errors.rs
+++ b/crates/rest-api/src/error/errors.rs
@@ -4,7 +4,6 @@
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
 use service::{
-    auth::{auth_service, jwt_service},
     members::user_service,
     notifications::notifier,
     sea_orm,
@@ -182,26 +181,6 @@ impl CustomErrorCode for MutationError {
 }
 impl_into_error!(MutationError);
 
-impl CustomErrorCode for jwt_service::Error {
-    fn error_code(&self) -> ErrorCode {
-        match self {
-            Self::Sign(_) | Self::Other(_) => ErrorCode::INTERNAL_SERVER_ERROR,
-            Self::Verify(_) | Self::InvalidClaim(_) => ErrorCode::UNAUTHORIZED,
-        }
-    }
-}
-impl_into_error!(jwt_service::Error);
-
-impl CustomErrorCode for auth_service::Error {
-    fn error_code(&self) -> ErrorCode {
-        match self {
-            Self::InvalidCredentials => ErrorCode::UNAUTHORIZED,
-            _ => ErrorCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-}
-impl_into_error!(auth_service::Error);
-
 impl CustomErrorCode for user_service::Error {
     fn error_code(&self) -> ErrorCode {
         match self {
@@ -233,10 +212,3 @@ impl CustomErrorCode for CreateServiceAccountError {
     }
 }
 impl_into_error!(CreateServiceAccountError);
-
-impl CustomErrorCode for std::io::Error {
-    fn error_code(&self) -> ErrorCode {
-        ErrorCode::INTERNAL_SERVER_ERROR
-    }
-}
-impl_into_error!(std::io::Error);

--- a/crates/rest-api/src/error/mod.rs
+++ b/crates/rest-api/src/error/mod.rs
@@ -16,6 +16,7 @@ use rocket::{
     serde::json::json,
     Request, Response,
 };
+use serde::Serialize;
 
 pub use self::errors::*;
 
@@ -51,25 +52,49 @@ pub enum LogLevel {
     Error,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Serialize)]
 #[error("{message}")]
 pub struct Error {
+    #[serde(rename = "error")]
     code: &'static str,
+
     message: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    recovery_suggestions: Vec<String>,
+
     /// HTTP status to return for this error.
+    #[serde(skip_serializing)]
     pub http_status: Status,
+
+    #[serde(skip_serializing)]
     http_headers: Vec<(String, String)>,
+
+    #[serde(skip_serializing)]
     log_level: LogLevel,
+
     /// Whether or not the error has already been logged.
     /// This way we can make sure an error is not logged twice.
+    #[serde(skip_serializing)]
     logged: AtomicBool,
 }
 
 impl Error {
-    pub fn new(code: ErrorCode, message: String, http_headers: Vec<(String, String)>) -> Self {
+    pub fn new(
+        code: ErrorCode,
+        message: String,
+        payload: Option<serde_json::Value>,
+        recovery_suggestions: Vec<String>,
+        http_headers: Vec<(String, String)>,
+    ) -> Self {
         Self {
             code: code.value,
             message,
+            payload,
+            recovery_suggestions,
             http_status: code.http_status,
             http_headers,
             log_level: code.log_level,
@@ -85,15 +110,27 @@ impl Error {
             return;
         }
 
+        let message = match self.recovery_suggestions.len() {
+            0 => self.message.clone(),
+            1 => format!(
+                "{} (recovery suggestion: {})",
+                self.message, self.recovery_suggestions[0],
+            ),
+            _ => format!(
+                "{} (recovery suggestions: {:?})",
+                self.message, self.recovery_suggestions,
+            ),
+        };
+
         // NOTE: `tracing` does not allow passing the log level dynamically
         //   therefore we introduced this custom `LogLevel` type and do a manual mapping.
         match self.log_level {
-            LogLevel::Trace => trace!("{}", self.message),
-            LogLevel::Debug => debug!("{}", self.message),
-            LogLevel::Info => info!("{}", self.message),
-            LogLevel::Warn => warn!("{}", self.message),
-            LogLevel::Error => error!("{}", self.message),
-        }
+            LogLevel::Trace => trace!("{message}"),
+            LogLevel::Debug => debug!("{message}"),
+            LogLevel::Info => info!("{message}"),
+            LogLevel::Warn => warn!("{message}"),
+            LogLevel::Error => error!("{message}"),
+        };
 
         self.logged.store(true, Ordering::Relaxed);
     }
@@ -105,10 +142,21 @@ impl Error {
     }
 
     fn as_json(&self) -> String {
-        json!({
-            "reason": self.code,
-        })
-        .to_string()
+        if cfg!(debug_assertions) {
+            serde_json::to_string(self).unwrap_or_else(|_| {
+                json!({
+                    "error": self.code,
+                    "message": self.message,
+                    "payload": self.payload,
+                })
+                .to_string()
+            })
+        } else {
+            json!({
+                "error": self.code,
+            })
+            .to_string()
+        }
     }
 
     /// Construct the HTTP response.
@@ -139,6 +187,12 @@ pub trait HttpApiError: std::fmt::Display {
     fn message(&self) -> String {
         format!("{self}")
     }
+    fn payload(&self) -> Option<serde_json::Value> {
+        None
+    }
+    fn recovery_suggestions(&self) -> Vec<String> {
+        vec![]
+    }
     fn http_headers(&self) -> Vec<(String, String)> {
         vec![]
     }
@@ -146,7 +200,13 @@ pub trait HttpApiError: std::fmt::Display {
 
 impl<E: HttpApiError> From<E> for Error {
     fn from(error: E) -> Self {
-        Self::new(error.code(), error.message(), error.http_headers())
+        Self::new(
+            error.code(),
+            error.message(),
+            error.payload(),
+            error.recovery_suggestions(),
+            error.http_headers(),
+        )
     }
 }
 

--- a/crates/rest-api/src/error/mod.rs
+++ b/crates/rest-api/src/error/mod.rs
@@ -61,7 +61,7 @@ pub struct Error {
     message: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    payload: Option<serde_json::Value>,
+    debug_info: Option<serde_json::Value>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     recovery_suggestions: Vec<String>,
@@ -86,14 +86,14 @@ impl Error {
     pub fn new(
         code: ErrorCode,
         message: String,
-        payload: Option<serde_json::Value>,
+        debug_info: Option<serde_json::Value>,
         recovery_suggestions: Vec<String>,
         http_headers: Vec<(String, String)>,
     ) -> Self {
         Self {
             code: code.value,
             message,
-            payload,
+            debug_info,
             recovery_suggestions,
             http_status: code.http_status,
             http_headers,
@@ -147,7 +147,7 @@ impl Error {
                 json!({
                     "error": self.code,
                     "message": self.message,
-                    "payload": self.payload,
+                    "debug_info": self.debug_info,
                 })
                 .to_string()
             })
@@ -187,7 +187,7 @@ pub trait HttpApiError: std::fmt::Display {
     fn message(&self) -> String {
         format!("{self}")
     }
-    fn payload(&self) -> Option<serde_json::Value> {
+    fn debug_info(&self) -> Option<serde_json::Value> {
         None
     }
     fn recovery_suggestions(&self) -> Vec<String> {
@@ -203,7 +203,7 @@ impl<E: HttpApiError> From<E> for Error {
         Self::new(
             error.code(),
             error.message(),
-            error.payload(),
+            error.debug_info(),
             error.recovery_suggestions(),
             error.http_headers(),
         )

--- a/crates/rest-api/src/features/auth/mod.rs
+++ b/crates/rest-api/src/features/auth/mod.rs
@@ -14,6 +14,10 @@ pub(super) fn routes() -> Vec<rocket::Route> {
 
 mod error {
     use http_auth_basic::AuthBasicError;
+    use service::{
+        auth::{auth_service, jwt_service},
+        prosody::ProsodyOAuth2Error,
+    };
 
     use crate::error::prelude::*;
 
@@ -25,4 +29,28 @@ mod error {
             r#"Basic realm="Admin only area", charset="UTF-8""#.into(),
         )]
     );
+
+    impl CustomErrorCode for jwt_service::Error {
+        fn error_code(&self) -> ErrorCode {
+            match self {
+                Self::Sign(_) | Self::Other(_) => ErrorCode::INTERNAL_SERVER_ERROR,
+                Self::Verify(_) | Self::InvalidClaim(_) => ErrorCode::UNAUTHORIZED,
+            }
+        }
+    }
+    impl_into_error!(jwt_service::Error);
+
+    impl CustomErrorCode for auth_service::Error {
+        fn error_code(&self) -> ErrorCode {
+            match self {
+                Self::InvalidCredentials
+                | Self::ProsodyOAuth2Err(ProsodyOAuth2Error::Unauthorized(_)) => {
+                    ErrorCode::UNAUTHORIZED
+                }
+                Self::ProsodyOAuth2Err(ProsodyOAuth2Error::Forbidden(_)) => ErrorCode::FORBIDDEN,
+                _ => ErrorCode::INTERNAL_SERVER_ERROR,
+            }
+        }
+    }
+    impl_into_error!(auth_service::Error);
 }

--- a/crates/rest-api/src/features/auth/mod.rs
+++ b/crates/rest-api/src/features/auth/mod.rs
@@ -40,17 +40,45 @@ mod error {
     }
     impl_into_error!(jwt_service::Error);
 
-    impl CustomErrorCode for auth_service::Error {
-        fn error_code(&self) -> ErrorCode {
+    impl HttpApiError for auth_service::Error {
+        fn code(&self) -> ErrorCode {
             match self {
-                Self::InvalidCredentials
-                | Self::ProsodyOAuth2Err(ProsodyOAuth2Error::Unauthorized(_)) => {
-                    ErrorCode::UNAUTHORIZED
-                }
-                Self::ProsodyOAuth2Err(ProsodyOAuth2Error::Forbidden(_)) => ErrorCode::FORBIDDEN,
+                Self::InvalidCredentials => ErrorCode::UNAUTHORIZED,
+                Self::ProsodyOAuth2Err(err) => err.code(),
                 _ => ErrorCode::INTERNAL_SERVER_ERROR,
             }
         }
+
+        fn message(&self) -> String {
+            std::format!("auth_service::Error: {self}")
+        }
+
+        fn debug_info(&self) -> Option<serde_json::Value> {
+            match self {
+                Self::ProsodyOAuth2Err(err) => err.debug_info(),
+                _ => None,
+            }
+        }
     }
-    impl_into_error!(auth_service::Error);
+
+    impl HttpApiError for ProsodyOAuth2Error {
+        fn code(&self) -> ErrorCode {
+            match self {
+                Self::Unauthorized(_) => ErrorCode::UNAUTHORIZED,
+                Self::Forbidden(_) => ErrorCode::FORBIDDEN,
+                _ => ErrorCode::INTERNAL_SERVER_ERROR,
+            }
+        }
+
+        fn message(&self) -> String {
+            std::format!("ProsodyOAuth2Error: {self}")
+        }
+
+        fn debug_info(&self) -> Option<serde_json::Value> {
+            match self {
+                Self::UnexpectedResponse(err) => err.debug_info(),
+                _ => None,
+            }
+        }
+    }
 }

--- a/crates/rest-api/src/features/init/init_server_config.rs
+++ b/crates/rest-api/src/features/init/init_server_config.rs
@@ -65,20 +65,32 @@ impl ErrorCode {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("XMPP server not initialized. Call `PUT {}` to initialize it.", uri!(crate::features::init::init_server_config_route))]
+#[error("XMPP server not initialized.")]
 pub struct ServerConfigNotInitialized;
 impl HttpApiError for ServerConfigNotInitialized {
     fn code(&self) -> ErrorCode {
         ErrorCode::SERVER_CONFIG_NOT_INITIALIZED
     }
+    fn recovery_suggestions(&self) -> Vec<String> {
+        vec![format!(
+            "Call `PUT {}` to initialize it.",
+            uri!(crate::features::init::init_server_config_route)
+        )]
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("Prose Pod address not initialized. Call `PUT {}` to initialize it.", uri!(crate::features::pod_config::set_pod_address_route))]
+#[error("Prose Pod address not initialized.")]
 pub struct PodAddressNotInitialized;
 impl HttpApiError for PodAddressNotInitialized {
     fn code(&self) -> ErrorCode {
         ErrorCode::POD_ADDRESS_NOT_INITIALIZED
+    }
+    fn recovery_suggestions(&self) -> Vec<String> {
+        vec![format!(
+            "Call `PUT {}` to initialize it.",
+            uri!(crate::features::pod_config::set_pod_address_route)
+        )]
     }
 }
 

--- a/crates/rest-api/static/api-docs/openapi.json
+++ b/crates/rest-api/static/api-docs/openapi.json
@@ -1809,9 +1809,9 @@
 		"schemas": {
 			"Error": {
 				"type": "object",
-				"required": ["reason"],
+				"required": ["error"],
 				"properties": {
-					"reason": {
+					"error": {
 						"type": "string",
 						"enum": [
 							"bad_request",
@@ -2709,7 +2709,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "workspace_already_initialized"
+							"error": "workspace_already_initialized"
 						}
 					}
 				}
@@ -2720,7 +2720,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "workspace_not_initialized"
+							"error": "workspace_not_initialized"
 						}
 					}
 				}
@@ -2731,7 +2731,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "server_config_already_initialized"
+							"error": "server_config_already_initialized"
 						}
 					}
 				}
@@ -2742,7 +2742,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "server_config_not_initialized"
+							"error": "server_config_not_initialized"
 						}
 					}
 				}
@@ -2753,7 +2753,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "pod_address_not_initialized"
+							"error": "pod_address_not_initialized"
 						}
 					}
 				}
@@ -2764,7 +2764,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "first_account_already_created"
+							"error": "first_account_already_created"
 						}
 					}
 				}
@@ -2775,7 +2775,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "unauthorized"
+							"error": "unauthorized"
 						}
 					}
 				},
@@ -2791,7 +2791,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "forbidden"
+							"error": "forbidden"
 						}
 					}
 				}
@@ -2802,7 +2802,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "not_found"
+							"error": "not_found"
 						}
 					}
 				}
@@ -2813,7 +2813,7 @@
 					"application/json": {
 						"schema": { "$ref": "#/components/schemas/Error" },
 						"example": {
-							"reason": "not_found"
+							"error": "not_found"
 						}
 					}
 				}

--- a/crates/rest-api/tests/features/dns-setup.feature
+++ b/crates/rest-api/tests/features/dns-setup.feature
@@ -14,7 +14,7 @@ Feature: DNS setup instructions
        When Rémi requests DNS setup instructions
        Then the HTTP status code should be Forbidden
         And the response content type should be JSON
-        And the error reason should be "forbidden"
+        And the error code should be "forbidden"
 
   """
   `SRV` records cannot point directly to IP addresses, we need to point it to a hostname.
@@ -145,4 +145,4 @@ Feature: DNS setup instructions
       Given the Prose Pod address has not been initialized
        When Valerian requests DNS setup instructions
        Then the HTTP status code should be Bad Request
-        And the error reason should be "pod_address_not_initialized"
+        And the error code should be "pod_address_not_initialized"

--- a/crates/rest-api/tests/features/pod-config/pod-address.feature
+++ b/crates/rest-api/tests/features/pod-config/pod-address.feature
@@ -32,7 +32,7 @@ Feature: Setting the Prose Pod address
        When Rémi sets the Prose Pod address to <address>
        Then the HTTP status code should be Forbidden
         And the response content type should be JSON
-        And the error reason should be "forbidden"
+        And the error code should be "forbidden"
 
     Examples:
       | address    |

--- a/crates/rest-api/tests/v1/init.rs
+++ b/crates/rest-api/tests/v1/init.rs
@@ -167,12 +167,12 @@ async fn when_init_first_account(world: &mut TestWorld, nickname: String, node: 
     world.result = Some(res.into());
 }
 
-#[then(expr = "the error reason should be {string}")]
+#[then(expr = "the error code should be {string}")]
 async fn then_error_reason(world: &mut TestWorld, reason: String) -> Result<(), serde_json::Error> {
     let res = world.result();
     assert_eq!(res.content_type, Some(ContentType::JSON));
     let body = serde_json::Value::from_str(res.body.as_ref().expect("No body found."))?;
-    assert_eq!(body["reason"].as_str(), Some(reason.as_str()));
+    assert_eq!(body["error"].as_str(), Some(reason.as_str()));
     Ok(())
 }
 
@@ -190,7 +190,11 @@ async fn then_error_workspace_not_initialized(world: &mut TestWorld) {
         res.body,
         Some(
             json!({
-                "reason": "workspace_not_initialized",
+                "error": "workspace_not_initialized",
+                "message": "WorkspaceControllerError: Workspace not initialized.",
+                "recovery_suggestions": [
+                    "Call `PUT /v1/workspace` to initialize it.",
+                ]
             })
             .to_string()
         )
@@ -206,7 +210,8 @@ async fn then_error_workspace_already_initialized(world: &mut TestWorld) {
         res.body,
         Some(
             json!({
-                "reason": "workspace_already_initialized",
+                "error": "workspace_already_initialized",
+                "message": "InitWorkspaceError error: Workspace already initialized.",
             })
             .to_string()
         )
@@ -227,7 +232,9 @@ async fn then_error_server_config_not_initialized(world: &mut TestWorld) {
         res.body,
         Some(
             json!({
-                "reason": "server_config_not_initialized",
+                "error": "server_config_not_initialized",
+                "message": "XMPP server not initialized.",
+                "recovery_suggestions": ["Call `PUT /v1/server/config` to initialize it."],
             })
             .to_string()
         )
@@ -243,7 +250,8 @@ async fn then_error_first_account_already_created(world: &mut TestWorld) {
         res.body,
         Some(
             json!({
-                "reason": "first_account_already_created",
+                "error": "first_account_already_created",
+                "message": "InitFirstAccountError error: First account already created.",
             })
             .to_string()
         )
@@ -259,7 +267,8 @@ async fn then_error_server_config_already_initialized(world: &mut TestWorld) {
         res.body,
         Some(
             json!({
-                "reason": "server_config_already_initialized",
+                "error": "server_config_already_initialized",
+                "message": "InitServerConfigError error: Could not init server config: XMPP server already initialized.",
             })
             .to_string()
         )

--- a/crates/service/src/errors.rs
+++ b/crates/service/src/errors.rs
@@ -1,0 +1,160 @@
+// prose-pod-api
+//
+// Copyright: 2024, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use reqwest::{header::HeaderMap, Request, Response, StatusCode, Url};
+use serde::{de::DeserializeOwned, Serialize, Serializer};
+
+#[derive(Debug, thiserror::Error, Serialize)]
+#[error("{message}")]
+pub struct UnexpectedHttpResponse {
+    pub message: String,
+    pub request: Option<RequestData>,
+    pub response: ResponseData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RequestData {
+    pub url: Url,
+    #[serde(serialize_with = "ser_headermap")]
+    pub headers: HeaderMap,
+    pub body: Option<String>,
+}
+
+impl RequestData {
+    pub async fn from(request: Request) -> Self {
+        Self {
+            url: request.url().clone(),
+            headers: request.headers().clone(),
+            body: request
+                .body()
+                .and_then(|body| body.as_bytes())
+                .map(|b| std::str::from_utf8(b).unwrap_or("<error>").to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResponseData {
+    #[serde(serialize_with = "ser_status_code")]
+    pub status: StatusCode,
+    #[serde(serialize_with = "ser_headermap")]
+    pub headers: HeaderMap,
+    #[serde(serialize_with = "ser_body")]
+    pub body: Result<serde_json::Value, String>,
+}
+
+impl ResponseData {
+    pub async fn from(response: Response) -> Self {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let text: Option<String> = response.text().await.ok();
+        let json: Option<serde_json::Value> = text
+            .as_ref()
+            .map(|s| serde_json::from_str(s).ok())
+            .flatten();
+        Self {
+            status,
+            headers,
+            body: json.ok_or(text.unwrap_or("<none>".to_string())),
+        }
+    }
+    pub fn text(&self) -> String {
+        match self.body.as_ref() {
+            Ok(json) => json.to_string(),
+            Err(text) => text.clone(),
+        }
+    }
+}
+impl ResponseData {
+    pub fn deserialize<T: DeserializeOwned>(self) -> Result<T, serde_json::Error> {
+        match self.body {
+            Ok(json) => serde_json::from_value(json),
+            Err(text) => serde_json::from_str(&text),
+        }
+    }
+}
+
+fn ser_status_code<S: Serializer>(sc: &StatusCode, serializer: S) -> Result<S::Ok, S::Error> {
+    sc.to_string().serialize(serializer)
+}
+fn headermap_to_vec(hm: &HeaderMap) -> Vec<String> {
+    hm.iter()
+        .map(|(k, v)| format!("{k}: {}", v.to_str().unwrap_or("<error>")))
+        .collect()
+}
+fn ser_headermap<S: Serializer>(hm: &HeaderMap, serializer: S) -> Result<S::Ok, S::Error> {
+    headermap_to_vec(hm).serialize(serializer)
+}
+fn ser_body<S: Serializer>(
+    body: &Result<serde_json::Value, String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match body {
+        Ok(json) => json.serialize(serializer),
+        Err(text) => text.serialize(serializer),
+    }
+}
+
+impl UnexpectedHttpResponse {
+    pub async fn new(
+        request: Option<RequestData>,
+        response: ResponseData,
+        error_description: impl FnOnce(Option<serde_json::Value>, Option<String>) -> String,
+    ) -> Self {
+        let response_text: Option<String> = match response.body.as_ref() {
+            Ok(json) => serde_json::to_string(&json).ok(),
+            Err(str) => Some(str.clone()),
+        };
+        let response_json: Option<serde_json::Value> = response.body.as_ref().ok().cloned();
+
+        Self {
+            message: error_description(response_json.clone(), response_text.clone()),
+            request,
+            response,
+        }
+    }
+}
+
+// impl UnexpectedHttpResponse {
+//     pub async fn new(
+//         request: Option<RequestData>,
+//         response: ResponseData,
+//         error_description: impl FnOnce(Option<serde_json::Value>, Option<String>) -> String,
+//     ) -> Self {
+//         let (request_url, request_headers, request_body) = if let Some(request) = request {
+//             (
+//                 Some(request.url.clone()),
+//                 Some(request.headers.clone()),
+//                 request
+//                     .body()
+//                     .and_then(|body| body.as_bytes())
+//                     .map(std::str::from_utf8)
+//                     .map(Result::ok)
+//                     .flatten()
+//                     .map(ToString::to_string),
+//             )
+//         } else {
+//             (None, None, None)
+//         };
+
+//         let response_status = response.status();
+//         let response_headers = response.headers().clone();
+//         let response_text: Option<String> = response.text().await.ok();
+//         let response_json: Option<serde_json::Value> = response_text
+//             .as_ref()
+//             .map(|s| serde_json::from_str(&s).ok())
+//             .flatten();
+
+//         Self {
+//             message: error_description(response_json.clone(), response_text.clone()),
+//             response_status,
+//             response_headers,
+//             response_body: response_json.or(response_text.map(serde_json::Value::String)),
+//             request_url,
+//             request_headers,
+//             request_body,
+//         }
+//     }
+// }

--- a/crates/service/src/features/xmpp/server_ctl.rs
+++ b/crates/service/src/features/xmpp/server_ctl.rs
@@ -16,7 +16,9 @@ use std::{
 use prose_xmpp::BareJid;
 use secrecy::SecretString;
 
-use crate::{members::MemberRole, server_config::ServerConfig, AppConfig};
+use crate::{
+    errors::UnexpectedHttpResponse, members::MemberRole, server_config::ServerConfig, AppConfig,
+};
 
 #[derive(Debug, Clone)]
 pub struct ServerCtl {
@@ -77,6 +79,12 @@ pub enum ServerCtlError {
     CommandFailed(Output),
     #[error("UTF-8 error: {0}")]
     Utf8Error(#[from] Utf8Error),
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+    #[error("Unexpected API response: {0}")]
+    UnexpectedResponse(UnexpectedHttpResponse),
     #[error("{0}")]
     Other(String),
 }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -5,9 +5,11 @@
 
 pub extern crate prose_xmpp;
 pub extern crate prosody_config;
+pub extern crate reqwest;
 extern crate xmpp_parsers;
 
 pub mod dependencies;
+pub mod errors;
 mod features;
 pub mod models;
 mod mutation_error;


### PR DESCRIPTION
Mainly improved how errors work. They now return a message, an optional payload and optional recovery suggestions in debug builds. Example:

```json
{
    "reason": "internal_server_error"
}
```

now becomes

```json
{
    "error": "internal_server_error",
    "message": "auth_service::Error: `ProsodyOAuth2` error: Unexpected API response: invalid JID",
    "debug_info": {
        "message": "invalid JID",
        "request": {
            "body": "grant_type=password&username=dev.admin%40test.org&password=&scope=xmpp",
            "headers": [
                "authorization: Basic ZGV2LmFkbWluQHRlc3Qub3JnOg==",
                "content-type: application/x-www-form-urlencoded"
            ],
            "url": "http://prose-pod-server:5280/oauth2/token"
        },
        "response": {
            "body": {
                "error": "invalid_request",
                "error_description": "invalid JID"
            },
            "headers": [
                "cache-control: no-store",
                "connection: Keep-Alive",
                "content-length: 61",
                "access-control-allow-headers: Content-Type",
                "x-request-id: 6v4AubEVmbzc",
                "access-control-max-age: 7200",
                "date: Thu, 14 Nov 2024 10:04:17 GMT",
                "pragma: no-cache",
                "content-type: application/json",
                "access-control-allow-credentials: true",
                "access-control-allow-origin: *",
                "access-control-allow-methods: OPTIONS, GET, POST"
            ],
            "status": "400 Bad Request"
        }
    }
}
```

and

```json
{
    "reason": "workspace_not_initialized"
}
```

becomes

```json
{
    "error": "workspace_not_initialized",
    "message": "WorkspaceControllerError: Workspace not initialized.",
    "recovery_suggestions": [
        "Call `PUT /v1/workspace` to initialize it."
    ]
}
```