### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
 
 name: Test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,8 @@ on:
 name: Test
 
 jobs:
-  test:
+  format:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,6 +18,25 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
+          override: true
+
+      - name: Verify versions
+        run: rustc --version && rustup --version && cargo --version
+
+      - name: Check code style
+        run: cargo fmt -- --check
+
+  smoke-test:
+    needs: format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           override: true
 
       - name: Verify versions
@@ -37,11 +55,101 @@ jobs:
       - name: Install SQLite3
         run: sudo apt-get update && sudo apt-get install -y sqlite3
 
-      - name: Create SQLite Database
-        run: sqlite3 database.sqlite ""
-
       - name: Test code
         run: cargo test
 
-      - name: Check code style
-        run: cargo fmt -- --check
+  integration-test:
+    needs: smoke-test
+    runs-on: ubuntu-latest
+    env:
+      PROSE_POD_SERVER_DIR: ${{ github.workspace }}/server
+      # For the API we don't use a subfolder just to make things easier.
+      PROSE_POD_API_DIR: ${{ github.workspace }}
+      PROSE_POD_SYSTEM_DIR: ${{ github.workspace }}/system
+    steps:
+      # NOTE: We **must** checkout `prose-pod-api` first otherwise checking it out
+      #   silently deletes the other checked out repositories.
+      - name: Checkout prose-pod-api
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.PROSE_POD_API_DIR }}
+          submodules: true
+      - name: Checkout prose-pod-server
+        uses: actions/checkout@v4
+        with:
+          repository: prose-im/prose-pod-server
+          path: ${{ env.PROSE_POD_SERVER_DIR }}
+          submodules: true
+      - name: Checkout prose-pod-system
+        uses: actions/checkout@v4
+        with:
+          repository: prose-im/prose-pod-system
+          path: ${{ env.PROSE_POD_SYSTEM_DIR }}
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Verify versions
+        run: rustc --version && rustup --version && cargo --version
+
+      - name: Cache build context
+        id: cache-cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo
+
+      # NOTE: Recommended by [the Task documentation](https://taskfile.dev/installation/#github-actions).
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      # SEE: https://github.com/cross-rs/cross/wiki/Getting-Started#installing-cross-1
+      - name: Install `cross`
+        run: cargo install cross
+
+      - name: Build images
+        run: scripts/run-locally/build-images
+
+      - name: Install SQLite3
+        run: sudo apt-get update && sudo apt-get install -y sqlite3
+
+      # Install our fork of Step CI (has more features we need).
+      # - name: Install Step CI
+      #   run: npm install -g stepci
+      - name: Checkout stepci-runner
+        uses: actions/checkout@v4
+        with:
+          repository: RemiBardon/stepci-runner
+          ref: prose
+          path: ${{ github.workspace }}/stepci-runner
+      - name: Build stepci-runner
+        run: |
+          cd "${{ github.workspace }}/stepci-runner"
+          npm install
+          npm run build
+          npm link
+      - name: Checkout stepci
+        uses: actions/checkout@v4
+        with:
+          repository: RemiBardon/stepci
+          ref: prose
+          path: ${{ github.workspace }}/stepci
+      - name: Build & install stepci
+        run: |
+          cd "${{ github.workspace }}/stepci"
+          # NOTE: `npm install` must be ran **before** `npm link @stepci/runner`
+          #   otherwise the link doesn't work properly and `stepci` fails at runtime
+          #   because of missing fixes from our branch.
+          npm install
+          npm link @stepci/runner
+          npm run build
+          npm install -g .
+
+      - name: Run integration tests
+        run: task integration-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-          override: true
 
       - name: Verify versions
         run: rustc --version && rustup --version && cargo --version
@@ -34,10 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Verify versions
         run: rustc --version && rustup --version && cargo --version
@@ -87,10 +82,7 @@ jobs:
           path: ${{ env.PROSE_POD_SYSTEM_DIR }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Verify versions
         run: rustc --version && rustup --version && cargo --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache build context
         id: cache-cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cache build context
         id: cache-cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/crates/rest-api/tests/integration/in-memory.env
+++ b/crates/rest-api/tests/integration/in-memory.env
@@ -1,3 +1,3 @@
 export ROCKET_DATABASES='{data={url="sqlite::memory:"}}'
 export PROSE_BOOTSTRAP__PROSE_POD_API_XMPP_PASSWORD='Nnu~bqPj"9D?m5,UJ/2kz3gM_:*=.edrGs){Z#Ex;&`@>C8B'
-export RUST_LOG='trace,sqlx=warn,hyper=warn,hyper_util=warn,sea_orm_migration=warn,hickory_proto=info,hickory_proto::xfer::dns_handle=debug,hickory_resolver=info,hickory_resolver::error=debug'
+export RUST_LOG='info,sqlx=warn,hyper=warn,hyper_util=warn,sea_orm_migration=warn,sea_orm=warn,hickory_resolver=warn,hickory_proto=info,hickory_proto::xfer::dns_handle=debug,prose_xmpp::client::module_context=warn,service=trace,service::features::prosody::prosody_rest=debug,prose_pod_api=debug'

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -23,7 +23,10 @@ COMPOSE_FILE="${INTEGRATION_TESTS_DIR:?}"/compose/compose.yaml
 
 before-all() {
 	trace 'Running "Before all"…'
-	# Nothing to do
+
+	# NOTE: When running in a GitHub Action, `cp /etc/prosody/prosody{.initial,}.cfg.lua` fails
+	#   because `$SERVER_ROOT` belongs to `runner:docker`.
+	[ -n "$GITHUB_ACTIONS" ] && sudo chmod -R a+w "${SERVER_ROOT:?}"
 }
 
 after-all() {
@@ -33,6 +36,11 @@ after-all() {
 
 cleanup() {
 	trace 'Cleaning up the Prose Pod…'
+
+	# NOTE: When running in a GitHub Action, `tools/cleanup` fails because `prose-pod-server` creates files
+	#   as `systemd-network:systemd-journal` and the current user (`runner:docker`) can't delete it.
+	[ -n "$GITHUB_ACTIONS" ] && sudo chmod -R a+w "${SERVER_ROOT:?}"
+
 	edo "${PROSE_POD_SYSTEM_DIR:?}"/tools/cleanup
 }
 


### PR DESCRIPTION
- Do not run GitHub Action twice in PRs (used to run because of both `push` and `pull_request` events)
- Update `RUST_LOG` in integration tests (make it less verbose)
- Run integration tests in GitHub Action (fixes #73)
- Use `dtolnay/rust-toolchain` instead of the unmaintained `actions-rs/toolchain` (fixes #82)
  
  > https://github.com/actions-rs/toolchain has been archived since Oct 13, 2023, which means it will not get security patches.
  >
  > David Tolnay ([@dtolnay](https://github.com/dtolnay)) is a big contributor in the Rust ecosystem, which can reassure us that this action will be maintained and vulnerability-free (at least more than an action from a shady user account).
  > Also the entire action code is less than 200 lines of understandable YAML and Bash, compared to [the 1.3MB JS script of actions-rs/toolchain](https://github.com/actions-rs/toolchain/blob/master/dist/index.js).

- Update `actions/cache` to `v4`

(Took me **47** tries what a pain in the ***)