### PR TITLE
chore: Run locally using tagged images instead of forcing local builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Finally, since integration tests run on final containers, you have to build `pro
 task build-image -- --debug
 # Build the Prose Pod Server image.
 PROSE_POD_SERVER_DIR=???
-docker build -t proseim/prose-pod-server:latest "${PROSE_POD_SERVER_DIR:?}"
+docker build -t proseim/prose-pod-server:local "${PROSE_POD_SERVER_DIR:?}"
 ```
 
 #### Running tests
@@ -90,7 +90,7 @@ docker build -t proseim/prose-pod-server:latest "${PROSE_POD_SERVER_DIR:?}"
 Then, run the tests using:
 
 ```bash
-task integration-test
+task integration-test -- --server=local
 ```
 
 If a test fails, Step CI will automatically print some additional information to help you debug the issue. We also print container logs so you can see internal errors.
@@ -101,18 +101,18 @@ If a test fails, Step CI will automatically print some additional information to
 
 ## Building the Docker image
 
-To build the Docker image, you can use the helper script (which builds the image as `proseim/prose-pod-api:latest`):
+To build the Docker image, you can use the helper script (which builds the image as `proseim/prose-pod-api:local`):
 
 ```bash
-task build-image [-- [TARGET_PLATFORM] [--debug] [--help]]
+task build-image [-- [--platform=TARGET_PLATFORM] [--debug] [--help]]
 ```
 
-If you don't set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:latest` for your local platform. If you set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:latest` for the desired platform. You can set `PROSE_POD_API_IMAGE` to override the final name of the image.
+If you don't set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:local` for your local platform. If you set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:local` for the desired platform. You can set `PROSE_POD_API_IMAGE` to override the final name of the image.
 
 To build the API in debug mode (e.g. to use predictable data generators), you can use the `--debug` argument:
 
 ```bash
-task build-image -- [TARGET_PLATFORM] --debug
+task build-image -- [--platform=TARGET_PLATFORM] --debug
 ```
 
 [Step CI]: https://stepci.com/ "Step CI homepage"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,12 +5,14 @@ version: "3"
 tasks:
   open-api-docs-ui:
     desc: Runs the Prose Pod API and opens the visual API documentation.
+    env:
+      SELF: task open-api-docs-ui
     cmds:
-      - ./scripts/open-api-docs-ui
+      - "{{.ROOT_DIR}}/scripts/open-api-docs-ui {{.CLI_ARGS}}"
   reset-db:
     desc: Backs up the database and resets it using `sea-orm-cli`.
     cmds:
-      - ./scripts/reset-db
+      - "{{.ROOT_DIR}}/scripts/reset-db"
   entity:
     desc: Generates database entities using `sea-orm-cli`.
     deps: [reset-db]
@@ -37,13 +39,17 @@ tasks:
       - 'sed -i '''' -E ''s/Tested at Rust version: `.+`/Tested at Rust version: `''"$(rustc --version)"''`/g'' README.md'
   smoke-test:
     desc: Runs smoke tests.
+    env:
+      SELF: task smoke-test
     cmds:
       - cargo test --test behavior -- {{.CLI_ARGS}}
   integration-test:
     desc: Runs integration tests.
+    env:
+      SELF: task integration-test
     cmds:
       # NOTE: Analytics are temporarily disabled because of [stepci/stepci#239](https://github.com/stepci/stepci/issues/239).
-      - STEPCI_DISABLE_ANALYTICS=true ./scripts/integration-test {{.CLI_ARGS}}
+      - "STEPCI_DISABLE_ANALYTICS=true {{.ROOT_DIR}}/scripts/integration-test {{.CLI_ARGS}}"
   update:
     desc: Updates all dependencies.
     deps: [update-redoc]
@@ -74,25 +80,42 @@ tasks:
     desc: Builds the Prose Pod API Docker image. Run `task build-image -- --help` for more info.
     env:
       SCRIPTS_ROOT: "{{.ROOT_DIR}}/scripts"
+      SELF: task build-image
     cmds:
       - "{{.ROOT_DIR}}/scripts/build-image {{.CLI_ARGS}}"
   local-init:
     desc: Initializes a local environment allowing one to run a Prose Pod API in one command (`task local-run`).
     dotenv: ["paths.env"]
+    env:
+      SELF: task local-init
     cmds:
       - "{{.ROOT_DIR}}/scripts/run-locally/init {{.CLI_ARGS}}"
   local-run:
     desc: Runs a Prose Pod API.
     dotenv: ["paths.env"]
+    env:
+      SELF: task local-run
     cmds:
       - "{{.ROOT_DIR}}/scripts/run-locally/run {{.CLI_ARGS}}"
   local-update:
     desc: Updates the Prose Pod API and the repositories it depends on to get the latest updates.
     dotenv: ["paths.env"]
+    env:
+      SELF: task local-update
     cmds:
       - "{{.ROOT_DIR}}/scripts/run-locally/update {{.CLI_ARGS}}"
+  local-build:
+    desc: Builds the Prose Pod API and the repositories it depends on without updating the code.
+    dotenv: ["paths.env"]
+    env:
+      SELF: task local-build
+    cmds:
+      - "{{.ROOT_DIR}}/scripts/run-locally/build-images {{.CLI_ARGS}}"
   local-reset:
     desc: Starts fresh with a Prose Pod API that has no data.
+    prompt: This command will delete all your local Prose data, do you want to continue?
     dotenv: ["paths.env"]
+    env:
+      SELF: task local-reset
     cmds:
       - "{{.ROOT_DIR}}/scripts/run-locally/reset {{.CLI_ARGS}}"

--- a/crates/rest-api/tests/integration/compose/compose.yaml
+++ b/crates/rest-api/tests/integration/compose/compose.yaml
@@ -1,6 +1,7 @@
+name: prose-pod-api-tests
 services:
   api:
-    image: proseim/prose-pod-api:latest
+    image: proseim/prose-pod-api:local
     ports:
       - "8000:8000"
     volumes:
@@ -19,7 +20,7 @@ services:
     dns: 172.20.0.42
 
   server:
-    image: proseim/prose-pod-server:latest
+    image: "${PROSE_POD_SERVER_IMAGE:-proseim/prose-pod-server:${PROSE_POD_SERVER_IMAGE_TAG:-${DEFAULT_DOCKER_TAG:-latest}}}"
     ports:
       - "5222:5222" # Client-to-server connections (public)
       - "5269:5269" # Server-to-server connections (public)

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -5,7 +5,14 @@ set -e
 
 # ===== CONSTANTS =====
 
+: ${SELF:="$(basename $0)"}
+
 source "$(dirname $0)"/constants.sh
+PROSE_POD_API_IMAGE_TAG="${LOCAL_DOCKER_TAG:?}"
+
+# Regenerate image name (so it's up-to-date in logs until arguments are passed).
+unset PROSE_POD_API_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
 
 # ===== HELPER FUNCTIONS =====
 
@@ -24,19 +31,20 @@ EOF
 usage() {
 	cat <<EOF
 $(format_title 'Usage:')
-  You want to build $(format_code ${PROSE_POD_API_IMAGE:?}) for a local usage:
-    $(format_command $(basename $0)) $(format_opt_arg '--|local') $(format_opt_arg --debug)
+  You want to build the Prose Pod API for a local usage:
+    $(format_command "${SELF:?}") $(format_opt_arg --debug)
+  You want to build $(format_code "${PROSE_POD_API_IMAGE_NAME:?}:latest"):
+    $(format_command "${SELF:?}") $(format_arg --tag=latest) $(format_opt_arg --debug)
   You want to build the Prose Pod API for a different platform:
-    $(format_command $(basename $0)) $(format_arg TARGET_PLATFORM) $(format_opt_arg --debug)
-
-$(format_title 'Positional arguments:')
-  $(format_opt_arg TARGET_PLATFORM)
-    The platform to compile for.
-    $(format_secondary "See the list of supported targets via $(format_code 'docker buildx ls').")
-    $(format_secondary "You can also pass $(format_code '--') or $(format_code 'local') if you don't want to cross-compile.")
+    $(format_command "${SELF:?}") $(format_arg --platform=TARGET_PLATFORM) $(format_opt_arg --debug)
 
 $(format_title 'Options:')
   $(format_subtitle 'Build phase options:')
+    $(format_flag --platform=TARGET_PLATFORM)
+      A platform to cross-compile for.
+      $(format_secondary "See the list of supported targets via $(format_code 'docker buildx ls').")
+    $(format_flag --tag=DOCKER_TAG)
+      Choose which version of the Prose Pod API to build (default: "${PROSE_POD_API_IMAGE_TAG:?}").
     $(format_flag --debug)
       Builds the Prose Pod API in debug mode.
     $(format_flag --no-pull)
@@ -62,32 +70,17 @@ help() {
 
 # ===== ARGUMENT PARSING =====
 
-case "${1:-local}" in
-	--help) help ;;
-	# Not cross-compiling.
-	--*|local)
-		change-build-target "$1" ;;
-	*) change-build-target "$1" ;;
-esac
-
-if [ -z "${TARGET_PLATFORM}" ]; then
-	info "Will build $(format_code $PROSE_POD_API_IMAGE) for the local platform."
-else
-	info "Will build $(format_code $PROSE_POD_API_IMAGE) for the $(format_code $TARGET_PLATFORM) platform."
-fi
-
-# Skip already interpreted argument.
-# NOTE: We need to check the argument count because `shift`
-#   will exit if the command was invoked with no argument.
-# NOTE: We also have to check that the first argument doesn't match `--*`
-#   in which case it would mean no `TARGET_PLATFORM` was passed.
-[ "$#" -gt 0 ] && [[ "$1" != --* ]] && shift
-
 CARGO_INSTALL_EXTRA_ARGS=()
 unset NO_PULL
 
 for arg in "$@"; do
 	case $arg in
+		--platform=*)
+			change-build-target "${arg#'--platform='}"
+			;;
+		--tag=*)
+			PROSE_POD_API_IMAGE_TAG="${arg#'--tag='}"
+			;;
 		--debug)
 			info 'Will build in debug mode.'
 			CARGO_INSTALL_EXTRA_ARGS+=('--profile=dev')
@@ -107,6 +100,16 @@ for arg in "$@"; do
 		*) die "Unknown argument: $(format_code $arg).\n$(usage)" ;;
 	esac
 done
+
+# Regenerate image name.
+unset PROSE_POD_API_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
+
+if [ -z "${TARGET_PLATFORM}" ]; then
+	info "Will build $(format_code $PROSE_POD_API_IMAGE) for the local platform."
+else
+	info "Will build $(format_code $PROSE_POD_API_IMAGE) for the $(format_code $TARGET_PLATFORM) platform."
+fi
 
 # ===== MAIN LOGIC =====
 

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -1,10 +1,13 @@
 # ===== Define local heplers =====
 
 image_name_() {
-	echo "${PROSE_DOCKER_ORG:?}/${1:?}:${DOCKER_TAG:?}"
+	local name="${1:?}"
+	echo "${PROSE_DOCKER_ORG:?}/${name:?}"
 }
-archive_name_() {
-	echo $@ | sed -e 's#/#%2F#' -e 's/:/%3A/'
+image_name_full_() {
+	local name="${1:?}"
+	local tag="${2:-"${DEFAULT_DOCKER_TAG:?}"}"
+	echo "${name:?}:${tag:?}"
 }
 
 # ===== Define constants =====
@@ -12,8 +15,14 @@ archive_name_() {
 #   It avoids resetting a variable when sourcing this file after the variable was overriden.
 
 : ${PROSE_DOCKER_ORG:=proseim}
-: ${DOCKER_TAG:=latest}
-: ${PROSE_POD_SERVER_IMAGE:=$(image_name_ prose-pod-server)}
-: ${PROSE_POD_SERVER_ARCHIVE:=$(archive_name_ $PROSE_POD_SERVER_IMAGE)}
-: ${PROSE_POD_API_IMAGE:=$(image_name_ prose-pod-api)}
-: ${PROSE_POD_API_ARCHIVE:=$(archive_name_ $PROSE_POD_API_IMAGE)}
+: ${DEFAULT_DOCKER_TAG:=latest}
+# Tag used to reference images built locally (e.g. uncommitted code).
+: ${LOCAL_DOCKER_TAG:=local}
+
+: ${PROSE_POD_SERVER_IMAGE_NAME:=$(image_name_ prose-pod-server)}
+: ${PROSE_POD_SERVER_IMAGE_TAG:=${DEFAULT_DOCKER_TAG:?}}
+: ${PROSE_POD_SERVER_IMAGE:=$(image_name_full_ "${PROSE_POD_SERVER_IMAGE_NAME:?}" "${PROSE_POD_SERVER_IMAGE_TAG}")}
+
+: ${PROSE_POD_API_IMAGE_NAME:=$(image_name_ prose-pod-api)}
+: ${PROSE_POD_API_IMAGE_TAG:=${DEFAULT_DOCKER_TAG:?}}
+: ${PROSE_POD_API_IMAGE:=$(image_name_full_ "${PROSE_POD_API_IMAGE_NAME:?}" "${PROSE_POD_API_IMAGE_TAG}")}

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -9,6 +9,17 @@ set -e
 export SCRIPTS_ROOT
 source "${SCRIPTS_ROOT:?}"/util.sh
 
+# ===== CONSTANTS =====
+
+: ${SELF:="$(basename $0)"}
+
+source "${SCRIPTS_ROOT:?}"/constants.sh
+PROSE_POD_API_IMAGE_TAG="${LOCAL_DOCKER_TAG:?}"
+
+# Regenerate image name (so it's up-to-date in logs until arguments are passed).
+unset PROSE_POD_API_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
+
 test-env-vars 'CONTRIBUTING.md' \
 	PROSE_POD_API_DIR \
 	PROSE_POD_SYSTEM_DIR
@@ -20,6 +31,32 @@ export ENV_FILE="${INTEGRATION_TESTS_DIR:?}"/in-memory.env
 export SERVER_ROOT="${INTEGRATION_TESTS_DIR:?}"/fs-root
 export DATABASE_PATH="${INTEGRATION_TESTS_DIR:?}"/integration-tests.sqlite
 COMPOSE_FILE="${INTEGRATION_TESTS_DIR:?}"/compose/compose.yaml
+
+# ===== ARGUMENT PARSING =====
+
+ARGS_=()
+for arg in "$@"; do
+	case $arg in
+		--server=*)
+			PROSE_POD_SERVER_IMAGE_TAG="${arg#'--server='}"
+			;;
+		# --help) help ;;
+		*) ARGS_+=("$arg") ;;
+	esac
+done
+set -- "${ARGS_[@]}"
+unset ARGS_
+
+# Regenerate image names.
+unset PROSE_POD_SERVER_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
+export PROSE_POD_API_IMAGE PROSE_POD_SERVER_IMAGE
+
+info "Selected versions:"
+info "- API: $(format_code $PROSE_POD_API_IMAGE)"
+info "- Server: $(format_code $PROSE_POD_SERVER_IMAGE)"
+
+# ===== MAIN LOGIC =====
 
 before-all() {
 	trace 'Running "Before all"…'
@@ -89,7 +126,7 @@ stepci_run() {
 }
 
 if [ "$#" -eq 0 ]; then
-	info "No argument provided. Will use all $(format_code '*.yaml') files in $(format_url "${STEPCI_DIR:?}")."
+	info "No test file provided. Will use all $(format_code '*.yaml') files in $(format_url "${STEPCI_DIR:?}")."
 	# WARN: Spaces in `*.yaml` files will break.
 	set -- $(cd "${STEPCI_DIR:?}"; find . -type f -name '*.yaml' | sed -E "s/\.\/(.+)\.yaml$/\1/")
 fi

--- a/scripts/open-api-docs-ui
+++ b/scripts/open-api-docs-ui
@@ -14,9 +14,8 @@ else
     die "Neither $(format_code xdg-open) nor $(format_code open) command found. Cannot open URL."
 fi
 
-warn "Because the Prose Pod API cannot be started alone, this script uses the local $(format_code proseim/prose-pod-api:latest) image. This means the OpenAPI description will not reload until you run $(format_code 'task build-image -- --debug') again."
+export ENV_FILE="${PROSE_POD_API_DIR:?}"/crates/rest-api/tests/integration/in-memory.env
+export SERVER_ROOT="${PROSE_POD_SYSTEM_DIR:?}"/server/pod
+export PROSE_CONFIG_FILE="${PROSE_POD_API_DIR:?}"/crates/rest-api/tests/integration/Prose-test.toml
 
-ENV_FILE="${PROSE_POD_API_DIR:?}"/crates/rest-api/tests/integration/in-memory.env \
-	SERVER_ROOT="${PROSE_POD_SYSTEM_DIR:?}"/server/pod \
-	PROSE_CONFIG_FILE="${PROSE_POD_API_DIR:?}"/crates/rest-api/tests/integration/Prose-test.toml \
-	docker compose -f "${PROSE_POD_SYSTEM_DIR:?}"/compose.yaml up
+task local-run -- "$@"

--- a/scripts/run-locally/build-images
+++ b/scripts/run-locally/build-images
@@ -6,14 +6,20 @@ set -e
 : ${SCRIPTS_ROOT:="$(dirname $0)/.."}
 export SCRIPTS_ROOT
 source "${SCRIPTS_ROOT:?}"/util.sh
+source "${SCRIPTS_ROOT:?}"/constants.sh
+
+# Regenerate image name.
+PROSE_POD_SERVER_IMAGE_TAG="${LOCAL_DOCKER_TAG:?}"
+unset PROSE_POD_SERVER_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
 
 test-env-vars 'tutorials/run-locally.md' \
-	PROSE_POD_SERVER_DIR \
-	PROSE_POD_API_DIR \
-	PROSE_POD_SYSTEM_DIR
+	PROSE_POD_API_DIR
 
 # Build the Prose Pod API image.
 edo task build-image -- --debug
 
-# Build the Prose Pod Server image.
-edo docker build -t proseim/prose-pod-server:latest "${PROSE_POD_SERVER_DIR:?}"
+if [ -n "${PROSE_POD_SERVER_DIR}" ]; then
+	# Build the Prose Pod Server image.
+	edo docker build -t "${PROSE_POD_SERVER_IMAGE:?}" "${PROSE_POD_SERVER_DIR:?}"
+fi

--- a/scripts/run-locally/init
+++ b/scripts/run-locally/init
@@ -8,13 +8,8 @@ export SCRIPTS_ROOT
 source "${SCRIPTS_ROOT:?}"/util.sh
 
 test-env-vars 'tutorials/run-locally.md' \
-	PROSE_POD_SERVER_DIR \
 	PROSE_POD_API_DIR \
 	PROSE_POD_SYSTEM_DIR
-
-# Clone prose-pod-server.
-[ -d "${PROSE_POD_SERVER_DIR:?}" ] || edo git clone https://github.com/prose-im/prose-pod-server.git "${PROSE_POD_SERVER_DIR:?}"
-edo git -C "${PROSE_POD_SERVER_DIR:?}" submodule update --init
 
 # Clone prose-pod-api.
 [ -d "${PROSE_POD_API_DIR:?}" ] || edo git clone https://github.com/prose-im/prose-pod-api.git "${PROSE_POD_API_DIR:?}"
@@ -26,11 +21,9 @@ edo git -C "${PROSE_POD_API_DIR:?}" submodule update --init
 # Create a `.env` file which we'll pass to prose-pod-api when it runs.
 edo echo "export ROCKET_DATABASES='{data={url=\"sqlite://database.sqlite?mode=rwc\"}}'
 export PROSE_BOOTSTRAP__PROSE_POD_API_XMPP_PASSWORD='jSq_fbnUZWBJ#eNK6Yt&dz%Vvr)RsA\`x~}p3^?>LE(-8@\"u.'
-export RUST_LOG='info,sqlx=warn,hyper=warn,hyper_util=warn,sea_orm_migration=warn,service=debug,prose_pod_api=debug'" \
+export RUST_LOG='debug,sqlx=warn,hyper=warn,hyper_util=warn,sea_orm_migration=warn,sea_orm=warn,hickory_resolver=warn,hickory_proto=info,hickory_proto::xfer::dns_handle=debug,prose_xmpp::client::module_context=warn,service=trace,service::features::prosody::prosody_rest=debug,prose_pod_api=trace'" \
 > "${PROSE_POD_SYSTEM_DIR:?}"/local-run.env
 
 # Initialize an empty `.sqlite` file because otherwise Compose creates a directory and the API crashes.
 DATABASE_PATH="${PROSE_POD_SYSTEM_DIR}"/local-run.sqlite
 [ -f "${DATABASE_PATH:?}" ] || echo '' > "${DATABASE_PATH:?}"
-
-traced "${SCRIPTS_ROOT:?}"/run-locally/build-images

--- a/scripts/run-locally/run
+++ b/scripts/run-locally/run
@@ -7,6 +7,11 @@ set -e
 export SCRIPTS_ROOT
 source "${SCRIPTS_ROOT:?}"/util.sh
 
+# ===== CONSTANTS =====
+
+: ${SELF:="$(basename $0)"}
+
+source "${SCRIPTS_ROOT:?}"/constants.sh
 test-env-vars 'tutorials/run-locally.md' \
 	PROSE_POD_SYSTEM_DIR
 
@@ -15,5 +20,72 @@ export SERVER_ROOT="${PROSE_POD_SYSTEM_DIR:?}"/server/pod
 export DATABASE_PATH="${PROSE_POD_SYSTEM_DIR:?}"/local-run.sqlite
 export PROSE_CONFIG_FILE="${PROSE_POD_SYSTEM_DIR:?}"/Prose-example.toml
 COMPOSE_FILE="${PROSE_POD_SYSTEM_DIR:?}"/compose.yaml
+
+# ===== HELPER FUNCTIONS =====
+
+description() {
+	cat <<EOF
+${Bold}Runs a Prose Pod API.${Bold_Off}
+
+By default, this script will use the latest released images but you can override
+this behavior by using $(format_arg --api=DOCKER_TAG) and $(format_arg --server=DOCKER_TAG).
+EOF
+}
+
+usage() {
+	cat <<EOF
+$(format_title 'Usage:')
+  You want to run the latest released versions:
+    $(format_command "${SELF:?}")
+  You want to run with the latest patches (latest commits, unreleased):
+    $(format_command "${SELF:?}") $(format_arg --) $(format_arg '--api=edge')
+  You want to run the image you built locally (e.g. for integration tests):
+    $(format_command "${SELF:?}") $(format_arg --) $(format_arg "--api=${LOCAL_DOCKER_TAG:?}")
+
+$(format_title 'Options:')
+  $(format_subtitle 'Version options:')
+    $(format_flag --api=DOCKER_TAG)
+      Choose which version of the Prose Pod API to run (default: $(format_code "${PROSE_POD_API_IMAGE_TAG:?}")).
+    $(format_flag --server=DOCKER_TAG)
+      Choose which version of the Prose Pod Server to run (default: $(format_code "${PROSE_POD_SERVER_IMAGE_TAG:?}")).
+
+  $(format_subtitle 'Miscellaneous options:')
+    $(format_flag --help)
+      Explains what the command does and how to use it.
+EOF
+}
+
+help() {
+	printf "$(description)\n"
+	echo ''
+	printf "$(usage)\n"
+	exit 0
+}
+
+# ===== ARGUMENT PARSING =====
+
+for arg in "$@"; do
+	case $arg in
+		--api=*)
+			PROSE_POD_API_IMAGE_TAG="${arg#'--api='}"
+			;;
+		--server=*)
+			PROSE_POD_SERVER_IMAGE_TAG="${arg#'--server='}"
+			;;
+		--help) help ;;
+		*) die "Unknown argument: $(format_code $arg).\n$(usage)" ;;
+	esac
+done
+
+# Regenerate image names.
+unset PROSE_POD_API_IMAGE PROSE_POD_SERVER_IMAGE
+source "${SCRIPTS_ROOT:?}"/constants.sh
+export PROSE_POD_API_IMAGE PROSE_POD_SERVER_IMAGE
+
+info "Selected versions:"
+info "- API: $(format_code $PROSE_POD_API_IMAGE)"
+info "- Server: $(format_code $PROSE_POD_SERVER_IMAGE)"
+
+# ===== MAIN LOGIC =====
 
 edo docker compose -f "${COMPOSE_FILE:?}" up

--- a/scripts/run-locally/update
+++ b/scripts/run-locally/update
@@ -9,14 +9,19 @@ set -e
 export SCRIPTS_ROOT
 source "${SCRIPTS_ROOT:?}"/util.sh
 
+# ===== CONSTANTS =====
+
+: ${SELF:="$(basename $0)"}
+
 # ===== HELPER FUNCTIONS =====
 
 description() {
 	cat <<EOF
 ${Bold}Updates the Prose Pod API and the repositories it depends on to get the latest updates.${Bold_Off}
 
-This script pulls the latest changes from $(format_code prose-pod-server), $(format_code prose-pod-api)
-and $(format_code prose-pod-system), then builds the Docker images.
+This script pulls the latest changes from $(format_code prose-pod-api) and $(format_code prose-pod-system),
+plus $(format_code prose-pod-server) if you have the repository locally.
+Use $(format_code task local-build) to build the images locally.
 EOF
 }
 
@@ -24,9 +29,9 @@ usage() {
 	cat <<EOF
 $(format_title 'Usage:')
   You want to update without changing the checked out branches:
-    $(format_command task local-update)
+    $(format_command "${SELF:?}")
   You want to test a hotfix made on a specific branch of the Prose Pod API:
-    $(format_command task local-update) $(format_arg --api-branch=BRANCH)
+    $(format_command "${SELF:?}") $(format_arg --api-branch=BRANCH)
 
 $(format_title 'Options:')
   $(format_subtitle 'Main options:')
@@ -74,14 +79,15 @@ done
 # ===== MAIN LOGIC =====
 
 test-env-vars 'tutorials/run-locally.md' \
-	PROSE_POD_SERVER_DIR \
 	PROSE_POD_API_DIR \
 	PROSE_POD_SYSTEM_DIR
 
-info 'Updating prose-pod-server…'
-[ -n "${SERVER_BRANCH}" ] && edo git -C "${PROSE_POD_SERVER_DIR:?}" checkout "${SERVER_BRANCH:?}"
-edo git -C "${PROSE_POD_SERVER_DIR:?}" pull || :
-edo git -C "${PROSE_POD_SERVER_DIR:?}" submodule update
+if [ -n "${PROSE_POD_SERVER_DIR}" ]; then
+	info 'Updating prose-pod-server…'
+	[ -n "${SERVER_BRANCH}" ] && edo git -C "${PROSE_POD_SERVER_DIR:?}" checkout "${SERVER_BRANCH:?}"
+	edo git -C "${PROSE_POD_SERVER_DIR:?}" pull || :
+	edo git -C "${PROSE_POD_SERVER_DIR:?}" submodule update
+fi
 
 info 'Updating prose-pod-api…'
 [ -n "${API_BRANCH}" ] && ( edo git -C "${PROSE_POD_API_DIR:?}" checkout "${API_BRANCH:?}" 2>/dev/null || edo git -C "${PROSE_POD_API_DIR:?}" checkout -t origin/"${API_BRANCH:?}" )
@@ -91,5 +97,3 @@ edo git -C "${PROSE_POD_API_DIR:?}" submodule update
 info 'Updating prose-pod-system…'
 [ -n "${SYSTEM_BRANCH}" ] && edo git -C "${PROSE_POD_SYSTEM_DIR:?}" checkout "${SYSTEM_BRANCH:?}"
 edo git -C "${PROSE_POD_SYSTEM_DIR:?}" pull || :
-
-traced "${SCRIPTS_ROOT:?}"/run-locally/build-images

--- a/tutorials/run-locally.md
+++ b/tutorials/run-locally.md
@@ -17,7 +17,7 @@ You probably have it installed already, but if you don't, have a look at
 
 Instead of using [GNU Make], we are using [Task] for its simplicity and flexibility.
 You can find installation instructions on [taskfile.dev/installation],
-or just run the folowing on macOS:
+or just run the following on macOS:
 
 ```bash
 brew install go-task
@@ -31,7 +31,7 @@ task -a
 
 #### Docker
 
-We need to build and run Docker container so you must have Docker installed.
+We need to run Docker images so you must have Docker installed.
 See [Install | Docker Docs](https://docs.docker.com/engine/install/).
 
 ### Initialize your environment
@@ -43,7 +43,6 @@ But before that, you must declare where you want the repositories to be
 (replace `???` by the desired location):
 
 ```sh
-export PROSE_POD_SERVER_DIR=???
 export PROSE_POD_API_DIR=???
 export PROSE_POD_SYSTEM_DIR=???
 ```
@@ -61,8 +60,7 @@ task --taskfile "${PROSE_POD_API_DIR:?}"/Taskfile.yaml local-init
 > which will be sourced automatically when you run the next commands:
 >
 > ```sh
-> echo "export PROSE_POD_SERVER_DIR='${PROSE_POD_SERVER_DIR:?}'
-> export PROSE_POD_API_DIR='${PROSE_POD_API_DIR:?}'
+> echo "export PROSE_POD_API_DIR='${PROSE_POD_API_DIR:?}'
 > export PROSE_POD_SYSTEM_DIR='${PROSE_POD_SYSTEM_DIR:?}'" \
 > >> "${PROSE_POD_API_DIR:?}"/paths.env
 > ```
@@ -81,12 +79,15 @@ At the root of the `prose-pod-api` repository, run:
 task local-run
 ```
 
-## When you want to update one of the repositories
-
-At the root of the `prose-pod-api` repository, run:
+The above command runs the latest released versions, but you can change this behavior:
 
 ```sh
-task local-update
+# Run latest patches (latest commits, unreleased):
+task local-run -- --api=edge
+# Run a specific version:
+task local-run -- --api=1.2.3
+task local-run -- --api=1.2
+task local-run -- --api=1
 ```
 
 ## When you want to start fresh with a Prose Pod API that has no data


### PR DESCRIPTION
## New features

- `task local-run` runs the latest released images (from [Docker Hub](https://hub.docker.com/r/proseim/prose-pod-api/tags))
  - Therefore, no more minutes-long local builds and no need to `task local-update` anymore
  - You can get the latest unreleased patches by running `task local-run -- --api=edge`
  - You don't need to have the `prose-pod-server` repository locally anymore
- `task open-api-docs-ui` uses the latest released images too (can be overridden with the same options as `task local-run`)
- `task build-image` accepts `--tag=DOCKER_TAG` to override the default `local` tag
- `task integration-test` accepts `--server=DOCKER_TAG` to override the image that will run (e.g. to use the locally built one instead of the latest release)
- And various improvements to documentation & logs

## Breaking

- `task build-image -- [TARGET_PLATFORM]` is now `task build-image -- [--platform=TARGET_PLATFORM]`. No more positional argument (and consistency with `docker buildx`.

## Notes

If you're not developing the API, you can now:

```sh
cargo uninstall cross
rm -rf "${PROSE_POD_SERVER_DIR:?}"
```