### PR TITLE
Add support for XEP-0357: Push Notifications

### DIFF
--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -6,6 +6,7 @@ mod m20240320_095326_create_workspace_invitation;
 mod m20240326_160834_create_notification;
 mod m20240506_080027_create_workspace;
 mod m20240830_080808_create_pod_config;
+mod m20241214_134500_add_push_notif_config;
 
 pub struct Migrator;
 
@@ -19,6 +20,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240326_160834_create_notification::Migration),
             Box::new(m20240506_080027_create_workspace::Migration),
             Box::new(m20240830_080808_create_pod_config::Migration),
+            Box::new(m20241214_134500_add_push_notif_config::Migration),
         ]
     }
 }

--- a/crates/migration/src/m20231221_172027_create_server_config.rs
+++ b/crates/migration/src/m20231221_172027_create_server_config.rs
@@ -37,7 +37,7 @@ impl MigrationTrait for Migration {
 }
 
 #[derive(DeriveIden)]
-enum ServerConfig {
+pub(super) enum ServerConfig {
     Table,
     Id,
     Domain,

--- a/crates/migration/src/m20241214_134500_add_push_notif_config.rs
+++ b/crates/migration/src/m20241214_134500_add_push_notif_config.rs
@@ -1,0 +1,55 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+use super::m20231221_172027_create_server_config::ServerConfig;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ServerConfig::Table)
+                    .add_column(boolean_null(NotifConfig::PushNotificationWithBody))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ServerConfig::Table)
+                    .add_column(boolean_null(NotifConfig::PushNotificationWithSender))
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ServerConfig::Table)
+                    .drop_column(NotifConfig::PushNotificationWithBody)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ServerConfig::Table)
+                    .drop_column(NotifConfig::PushNotificationWithSender)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum NotifConfig {
+    PushNotificationWithBody,
+    PushNotificationWithSender,
+}

--- a/crates/rest-api/src/features/server_config/mod.rs
+++ b/crates/rest-api/src/features/server_config/mod.rs
@@ -6,11 +6,13 @@
 mod file_upload;
 mod get_server_config;
 mod message_archive;
+mod push_notifications;
 mod util;
 
 pub use file_upload::*;
 pub use get_server_config::*;
 pub use message_archive::*;
+pub use push_notifications::*;
 
 pub(super) fn routes() -> Vec<rocket::Route> {
     routes![
@@ -26,5 +28,11 @@ pub(super) fn routes() -> Vec<rocket::Route> {
         set_message_archive_enabled_route,
         set_message_archive_retention_route,
         reset_message_archive_retention_route,
+        // Push notifications
+        reset_push_notifications_config_route,
+        set_push_notification_with_body_route,
+        reset_push_notification_with_body_route,
+        set_push_notification_with_sender_route,
+        reset_push_notification_with_sender_route,
     ]
 }

--- a/crates/rest-api/src/features/server_config/push_notifications.rs
+++ b/crates/rest-api/src/features/server_config/push_notifications.rs
@@ -1,0 +1,43 @@
+// prose-pod-api
+//
+// Copyright: 2024, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use rocket::serde::json::Json;
+use service::{server_config::ServerConfig, xmpp::ServerManager};
+
+use crate::{guards::LazyGuard, server_config_reset_route, server_config_set_route};
+
+server_config_reset_route!(
+    "/v1/server/config/push-notifications/reset",
+    reset_push_notifications_config,
+    reset_push_notifications_config_route
+);
+
+server_config_set_route!(
+    "/v1/server/config/push-notification-with-body",
+    SetPushNotificationWithBodyRequest,
+    bool,
+    push_notification_with_body,
+    set_push_notification_with_body,
+    set_push_notification_with_body_route
+);
+server_config_reset_route!(
+    "/v1/server/config/push-notification-with-body/reset",
+    reset_push_notification_with_body,
+    reset_push_notification_with_body_route
+);
+
+server_config_set_route!(
+    "/v1/server/config/push-notification-with-sender",
+    SetPushNotificationWithSenderRequest,
+    bool,
+    push_notification_with_sender,
+    set_push_notification_with_sender,
+    set_push_notification_with_sender_route
+);
+server_config_reset_route!(
+    "/v1/server/config/push-notification-with-sender/reset",
+    reset_push_notification_with_sender,
+    reset_push_notification_with_sender_route
+);

--- a/crates/rest-api/static/api-docs/openapi.json
+++ b/crates/rest-api/static/api-docs/openapi.json
@@ -704,7 +704,12 @@
 				"operationId": "get_server_config",
 				"security": [{ "BearerAuth": [] }],
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -726,7 +731,12 @@
 					}
 				},
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -748,7 +758,12 @@
 					}
 				},
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -760,7 +775,12 @@
 				"operationId": "set_file_storage_encryption_scheme",
 				"security": [{ "BearerAuth": [] }],
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -772,7 +792,12 @@
 				"operationId": "reset_messaging_config",
 				"security": [{ "BearerAuth": [] }],
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -794,7 +819,12 @@
 					}
 				},
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -806,7 +836,12 @@
 				"operationId": "reset_message_archive_retention",
 				"security": [{ "BearerAuth": [] }],
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -818,7 +853,12 @@
 				"operationId": "reset_files_config",
 				"security": [{ "BearerAuth": [] }],
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -840,7 +880,117 @@
 					}
 				},
 				"responses": {
-					"$ref": "#/components/responses/GetServerConfigAllResponses"
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
+				}
+			}
+		},
+		"/v1/server/config/push-notifications/reset": {
+			"put": {
+				"tags": ["Server / Configuration"],
+				"summary": "Reset 'Push notifications' configuration",
+				"description": "Reset the 'Push notifications' configuration to its default value.",
+				"operationId": "reset_push_notifications_config",
+				"security": [{ "BearerAuth": [] }],
+				"responses": {
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
+				}
+			}
+		},
+		"/v1/server/config/push-notification-with-body/reset": {
+			"put": {
+				"tags": ["Server / Configuration"],
+				"summary": "Reset 'Push notification with body'",
+				"description": "Reset 'Push notification with body' to its default value.",
+				"operationId": "reset_push_notification_with_body",
+				"security": [{ "BearerAuth": [] }],
+				"responses": {
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
+				}
+			}
+		},
+		"/v1/server/config/push-notification-with-body": {
+			"put": {
+				"tags": ["Server / Configuration"],
+				"summary": "Change 'Push notification with body'",
+				"description": "Whether or not to send the real message body to remote pubsub node. Without end-to-end encryption, enabling this may expose your message contents to your client developers and OS vendor. Not recommended.",
+				"operationId": "set_push_notification_with_body",
+				"security": [{ "BearerAuth": [] }],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SetPushNotificationWithBodyRequest"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
+				}
+			}
+		},
+		"/v1/server/config/push-notification-with-sender/reset": {
+			"put": {
+				"tags": ["Server / Configuration"],
+				"summary": "Reset 'Push notification with sender'",
+				"description": "Reset 'Push notification with sender' to its default value.",
+				"operationId": "reset_push_notification_with_sender",
+				"security": [{ "BearerAuth": [] }],
+				"responses": {
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
+				}
+			}
+		},
+		"/v1/server/config/push-notification-with-sender": {
+			"put": {
+				"tags": ["Server / Configuration"],
+				"summary": "Change 'Push notification with sender'",
+				"description": "Whether or not to send the real message sender to remote pubsub node. Enabling this may expose your contacts to your client developers and OS vendor. Not recommended.",
+				"operationId": "set_push_notification_with_sender",
+				"security": [{ "BearerAuth": [] }],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SetPushNotificationWithSenderRequest"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": { "$ref": "#/components/responses/ServerConfig" },
+					"400": {
+						"$ref": "#/components/responses/ServerConfigNotInitialized"
+					},
+					"401": { "$ref": "#/components/responses/Unauthorized" },
+					"403": { "$ref": "#/components/responses/Forbidden" }
 				}
 			}
 		},
@@ -1982,7 +2132,9 @@
 					"minimum_cipher_suite",
 					"federation_enabled",
 					"settings_backup_interval",
-					"user_data_backup_interval"
+					"user_data_backup_interval",
+					"push_notification_with_body",
+					"push_notification_with_sender"
 				],
 				"properties": {
 					"domain": {
@@ -2048,6 +2200,16 @@
 						"type": "string",
 						"format": "duration",
 						"default": "P1W"
+					},
+					"push_notification_with_body": {
+						"description": "Whether or not to send the real message body to remote pubsub node. Without end-to-end encryption, enabling this may expose your message contents to your client developers and OS vendor. Not recommended.",
+						"type": "boolean",
+						"default": false
+					},
+					"push_notification_with_sender": {
+						"description": "Whether or not to send the real message sender to remote pubsub node. Enabling this may expose your contacts to your client developers and OS vendor. Not recommended.",
+						"type": "boolean",
+						"default": false
 					}
 				}
 			},
@@ -2180,6 +2342,24 @@
 				"required": ["message_archive_enabled"],
 				"properties": {
 					"message_archive_enabled": {
+						"type": "boolean"
+					}
+				}
+			},
+			"SetPushNotificationWithBodyRequest": {
+				"type": "object",
+				"required": ["push_notification_with_body"],
+				"properties": {
+					"push_notification_with_body": {
+						"type": "boolean"
+					}
+				}
+			},
+			"SetPushNotificationWithSenderRequest": {
+				"type": "object",
+				"required": ["push_notification_with_sender"],
+				"properties": {
+					"push_notification_with_sender": {
 						"type": "boolean"
 					}
 				}
@@ -2846,18 +3026,13 @@
 					}
 				}
 			},
-			"GetServerConfigAllResponses": {
-				"200": {
-					"description": "Success",
-					"content": {
-						"application/json": {
-							"schema": { "$ref": "#/components/schemas/ServerConfig" }
-						}
+			"ServerConfig": {
+				"description": "Success",
+				"content": {
+					"application/json": {
+						"schema": { "$ref": "#/components/schemas/ServerConfig" }
 					}
-				},
-				"400": { "$ref": "#/components/responses/ServerConfigNotInitialized" },
-				"401": { "$ref": "#/components/responses/Unauthorized" },
-				"403": { "$ref": "#/components/responses/Forbidden" }
+				}
 			}
 		},
 		"parameters": {

--- a/crates/service/src/features/app_config/defaults.rs
+++ b/crates/service/src/features/app_config/defaults.rs
@@ -122,6 +122,14 @@ pub fn server_defaults_user_data_backup_interval() -> String {
     "P1W".to_string()
 }
 
+pub fn server_defaults_push_notification_with_body() -> bool {
+    false
+}
+
+pub fn server_defaults_push_notification_with_sender() -> bool {
+    false
+}
+
 pub fn branding_page_title() -> String {
     "Prose Pod API".to_string()
 }

--- a/crates/service/src/features/app_config/mod.rs
+++ b/crates/service/src/features/app_config/mod.rs
@@ -175,6 +175,8 @@ pub struct ConfigServerDefaults {
     pub federation_enabled: bool,
     pub settings_backup_interval: String,
     pub user_data_backup_interval: String,
+    pub push_notification_with_body: bool,
+    pub push_notification_with_sender: bool,
 }
 
 impl Default for ConfigServerDefaults {
@@ -192,6 +194,9 @@ impl Default for ConfigServerDefaults {
             federation_enabled: defaults::server_defaults_federation_enabled(),
             settings_backup_interval: defaults::server_defaults_settings_backup_interval(),
             user_data_backup_interval: defaults::server_defaults_user_data_backup_interval(),
+            push_notification_with_body: defaults::server_defaults_push_notification_with_body(),
+            push_notification_with_sender: defaults::server_defaults_push_notification_with_sender(
+            ),
         }
     }
 }

--- a/crates/service/src/features/prosody/prosody_config_from_db.rs
+++ b/crates/service/src/features/prosody/prosody_config_from_db.rs
@@ -189,6 +189,7 @@ impl ProseDefault for prosody_config::ProsodyConfig {
                         "server_contact_info",
                         "websocket",
                         "s2s_bidi",
+                        "cloud_notify",
                     ]
                     .into_iter()
                     .map(ToString::to_string)

--- a/crates/service/src/features/server_config/entities/server_config.rs
+++ b/crates/service/src/features/server_config/entities/server_config.rs
@@ -37,6 +37,8 @@ pub struct Model {
     pub federation_enabled: Option<bool>,
     pub settings_backup_interval: Option<String>,
     pub user_data_backup_interval: Option<String>,
+    pub push_notification_with_body: Option<bool>,
+    pub push_notification_with_sender: Option<bool>,
 }
 
 impl Model {
@@ -56,6 +58,8 @@ impl Model {
             federation_enabled: self.federation_enabled(defaults),
             settings_backup_interval: self.settings_backup_interval(defaults).to_owned(),
             user_data_backup_interval: self.user_data_backup_interval(defaults).to_owned(),
+            push_notification_with_body: self.push_notification_with_body(defaults).to_owned(),
+            push_notification_with_sender: self.push_notification_with_sender(defaults).to_owned(),
         }
     }
     /// Same as [Model::with_default_values], used in places where we have easier access to a full [AppConfig].
@@ -100,6 +104,8 @@ impl Model {
     get_or_default!(federation_enabled, bool);
     get_or_default_string!(settings_backup_interval);
     get_or_default_string!(user_data_backup_interval);
+    get_or_default!(push_notification_with_body, bool);
+    get_or_default!(push_notification_with_sender, bool);
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/service/src/features/server_config/models/server_config.rs
+++ b/crates/service/src/features/server_config/models/server_config.rs
@@ -21,4 +21,6 @@ pub struct ServerConfig {
     pub federation_enabled: bool,
     pub settings_backup_interval: String,
     pub user_data_backup_interval: String,
+    pub push_notification_with_body: bool,
+    pub push_notification_with_sender: bool,
 }

--- a/crates/service/src/features/xmpp/server_manager.rs
+++ b/crates/service/src/features/xmpp/server_manager.rs
@@ -199,6 +199,17 @@ impl ServerManager {
             .await?;
         Ok(model)
     }
+
+    pub async fn reset_push_notifications_config(&self) -> Result<ServerConfig, Error> {
+        trace!("Resetting push notifications configuration…");
+        let model = self
+            .update(|active| {
+                active.push_notification_with_body = Set(None);
+                active.push_notification_with_sender = Set(None);
+            })
+            .await?;
+        Ok(model)
+    }
 }
 
 impl ServerManager {
@@ -303,6 +314,21 @@ impl ServerManager {
         PossiblyInfinite<Duration<DateLike>>,
         set_file_storage_retention,
         file_storage_retention
+    );
+
+    // Push notifications
+    set_bool!(set_push_notification_with_body, push_notification_with_body);
+    reset!(
+        reset_push_notification_with_body,
+        push_notification_with_body
+    );
+    set_bool!(
+        set_push_notification_with_sender,
+        push_notification_with_sender
+    );
+    reset!(
+        reset_push_notification_with_sender,
+        push_notification_with_sender
     );
 }
 

--- a/crates/service/tests/prosody/snapshots/behavior__prosody__default_config.snap
+++ b/crates/service/tests/prosody/snapshots/behavior__prosody__default_config.snap
@@ -57,6 +57,7 @@ modules_enabled = {
   "server_contact_info";
   "websocket";
   "s2s_bidi";
+  "cloud_notify";
   "mam";
 }
 

--- a/crates/service/tests/prosody/snapshots/behavior__prosody__minimal_config.snap
+++ b/crates/service/tests/prosody/snapshots/behavior__prosody__minimal_config.snap
@@ -57,6 +57,7 @@ modules_enabled = {
   "server_contact_info";
   "websocket";
   "s2s_bidi";
+  "cloud_notify";
 }
 
 -- Path to SSL key and certificate for all server domains


### PR DESCRIPTION
- [x] Enable `mod_cloud_notify` (fixes #87)
- [x] Allow customization of `mod_cloud_notify` configuration options (fixes #88)
  - 5 new routes:
    - `PUT /v1/server/config/push-notifications/reset`
    - `PUT /v1/server/config/push-notification-with-body/reset`
    - `PUT /v1/server/config/push-notification-with-body`
    - `PUT /v1/server/config/push-notification-with-sender/reset`
    - `PUT /v1/server/config/push-notification-with-sender`
  - 2 new fields in `ServerConfig`:
    
    ```diff
      "required": [
         ...
    +   "push_notification_with_body",
    +   "push_notification_with_sender"
      ],
    ```