### PR TITLE
feat: Add a default value for `databases.main.url`

### DIFF
--- a/crates/service/src/features/app_config/defaults.rs
+++ b/crates/service/src/features/app_config/defaults.rs
@@ -19,7 +19,7 @@ use crate::{
     models::{DateLike, Duration, JidNode, PossiblyInfinite, TimeLike},
 };
 
-use super::ConfigServiceAccount;
+use super::{ConfigDatabase, ConfigServiceAccount};
 
 pub fn service_accounts_prose_pod_api() -> ConfigServiceAccount {
     ConfigServiceAccount {
@@ -154,13 +154,24 @@ pub fn notify_email_smtp_encrypt() -> bool {
     true
 }
 
-pub fn databases_max_connections() -> usize {
+pub fn databases_main() -> ConfigDatabase {
+    ConfigDatabase {
+        url: "sqlite://database.sqlite?mode=rwc".to_string(),
+        min_connections: Default::default(),
+        max_connections: database_max_connections(),
+        connect_timeout: database_connect_timeout(),
+        idle_timeout: Default::default(),
+        sqlx_logging: Default::default(),
+    }
+}
+
+pub fn database_max_connections() -> usize {
     let workers: usize =
         std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
     workers * 4
 }
 
-pub fn databases_connect_timeout() -> u64 {
+pub fn database_connect_timeout() -> u64 {
     5
 }
 

--- a/crates/service/src/features/app_config/mod.rs
+++ b/crates/service/src/features/app_config/mod.rs
@@ -54,6 +54,7 @@ pub struct AppConfig {
     pub branding: ConfigBranding,
     #[serde(default)]
     pub notify: ConfigNotify,
+    #[serde(default)]
     pub databases: ConfigDatabases,
     /// IP address to serve on.
     #[serde(default = "defaults::address")]
@@ -280,7 +281,16 @@ pub struct ConfigNotifyEmail {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConfigDatabases {
+    #[serde(default = "defaults::databases_main")]
     pub main: ConfigDatabase,
+}
+
+impl Default for ConfigDatabases {
+    fn default() -> Self {
+        Self {
+            main: defaults::databases_main(),
+        }
+    }
 }
 
 /// Inspired by <https://github.com/SeaQL/sea-orm/blob/bead32a0d812fd9c80c57e91e956e9d90159e067/sea-orm-rocket/lib/src/config.rs>.
@@ -289,9 +299,9 @@ pub struct ConfigDatabase {
     pub url: String,
     #[serde(default)]
     pub min_connections: Option<u32>,
-    #[serde(default = "defaults::databases_max_connections")]
+    #[serde(default = "defaults::database_max_connections")]
     pub max_connections: usize,
-    #[serde(default = "defaults::databases_connect_timeout")]
+    #[serde(default = "defaults::database_connect_timeout")]
     pub connect_timeout: u64,
     #[serde(default)]
     pub idle_timeout: Option<u64>,

--- a/local-run/scenarios/default/Prose.toml
+++ b/local-run/scenarios/default/Prose.toml
@@ -8,9 +8,6 @@
 page_url = "http://admin.prose.org.local/"
 company_name = "Prose (local)"
 
-[databases.main]
-url = "sqlite://database.sqlite?mode=rwc"
-
 [notify.email]
 pod_address = "pod@prose.org.local"
 


### PR DESCRIPTION
Simplifies `Prose.toml` configuration files.