### PR TITLE
chore(ci): Speed up `edge` build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,3 +99,5 @@ jobs:
             linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            CARGO_PROFILE=${{ startsWith(github.ref, 'refs/tags/') && 'release' || 'staging' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Build image
         # NOTE: We need to build in debug mode because we need to use
         #   `debug_only` configuration during integration tests.
-        run: task build-image -- --debug
+        run: task build-image -- --profile=dev
 
       - name: Install SQLite3
         run: sudo apt-get update && sudo apt-get install -y sqlite3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,15 +77,15 @@ If a test fails, Step CI will automatically print some additional information to
 To build the Docker image, you can use the helper script (which builds the image as `proseim/prose-pod-api:local`):
 
 ```bash
-task build-image [-- [--platform=TARGET_PLATFORM] [--debug] [--help]]
+task build-image [-- [--platform=TARGET_PLATFORM] [--profile=CARGO_PROFILE] [--help]]
 ```
 
 If you don't set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:local` for your local platform. If you set `TARGET_PLATFORM`, `build-image` will build `proseim/prose-pod-api:local` for the desired platform. You can set `PROSE_POD_API_IMAGE` to override the final name of the image.
 
-To build the API in debug mode (e.g. to use predictable data generators), you can use the `--debug` argument:
+To build the API in debug mode (e.g. to use predictable data generators), you can use the `--profile=dev` argument:
 
 ```bash
-task build-image -- [--platform=TARGET_PLATFORM] --debug
+task build-image -- [--platform=TARGET_PLATFORM] --profile=dev
 ```
 
 [Step CI]: https://stepci.com/ "Step CI homepage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,20 +79,34 @@ jid = { version = "0.11", default-features = false }
 minidom = { version = "0.16", default-features = false }
 xmpp-parsers = { version = "0.21", default-features = false }
 
+# See defaults at <https://doc.rust-lang.org/cargo/reference/profiles.html#dev>.
+# NOTE: We made some values explicit, even if they're already the default.
 [profile.dev]
 opt-level = 0
-debug = true
+# NOTE: In most cases, we won't need debug information in the binary (which adds a LOT of bloat).
+#   If needed, use the `dev-debug` profile.
+debug = false
 debug-assertions = true
-strip = "debuginfo"
+
+[profile.dev-debug]
+inherits = "dev"
+debug = true
 
 [profile.staging]
 inherits = "dev"
-opt-level = 1
 lto = "thin"
-
-[profile.release]
-opt-level = "s"
-lto = true
 debug = false
 debug-assertions = false
+panic = "abort"
+incremental = true
+
+# See defaults at <https://doc.rust-lang.org/cargo/reference/profiles.html#release>.
+# NOTE: We made some values explicit, even if they're already the default.
+[profile.release]
+opt-level = "s"
+lto = "thin"
+debug = false
+debug-assertions = false
+# NOTE: No need to `strip = "debuginfo"` since debug info won't be generated in the first place.
+strip = "symbols"
 panic = "abort"

--- a/local-run/scripts/build-images
+++ b/local-run/scripts/build-images
@@ -15,7 +15,7 @@ test-env-vars 'tutorials/run-locally.md' \
 	PROSE_POD_API_DIR
 
 # Build the Prose Pod API image.
-edo task build-image -- --debug
+edo task build-image -- --profile=dev
 
 if [ -n "${PROSE_POD_SERVER_DIR}" ] && [ -d "${PROSE_POD_SERVER_DIR:?}" ]; then
 	# Build the Prose Pod Server image.

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -29,11 +29,11 @@ usage() {
 	cat <<EOF
 $(format_title 'Usage:')
   You want to build the Prose Pod API for a local usage:
-    $(format_command "${SELF:?}") $(format_opt_arg --debug)
+    $(format_command "${SELF:?}") $(format_opt_arg --profile=dev)
   You want to build $(format_code "${PROSE_POD_API_IMAGE_NAME:?}:latest"):
-    $(format_command "${SELF:?}") $(format_arg --tag=latest) $(format_opt_arg --debug)
+    $(format_command "${SELF:?}") $(format_arg --tag=latest)
   You want to build the Prose Pod API for a different platform:
-    $(format_command "${SELF:?}") $(format_arg --platform=TARGET_PLATFORM) $(format_opt_arg --debug)
+    $(format_command "${SELF:?}") $(format_arg --platform=TARGET_PLATFORM)
 
 $(format_title 'Options:')
   $(format_subtitle 'Build phase options:')
@@ -42,8 +42,9 @@ $(format_title 'Options:')
       $(format_secondary "See the list of supported targets via $(format_code 'docker buildx ls').")
     $(format_flag --tag=DOCKER_TAG)
       Choose which version of the Prose Pod API to build (default: "${PROSE_POD_API_IMAGE_TAG:?}").
-    $(format_flag --debug)
-      Builds the Prose Pod API in debug mode.
+    $(format_flag --profile=CARGO_PROFILE)
+      Choose which Cargo profile to use when building the Prose Pod API.
+      $(format_secondary "Note: $(format_code '--profile=dev') enables $(format_code 'debug_only') configuration.")
     $(format_flag --no-pull)
       Do not pull referenced Docker images.
       $(format_secondary "Speeds up the builds and does not use the network, but does not update base images.")
@@ -51,6 +52,12 @@ $(format_title 'Options:')
   $(format_subtitle 'Miscellaneous options:')
     $(format_flag --help)
       Explains what the command does and how to use it.
+    $(format_flag --dry-run)
+      Do a dry run (i.e. print what would be executed instead of running it).
+    $(format_flag --debug)
+      Log debug messages when running the script.
+    $(format_flag --trace)
+      Log tracing messages when running the script.
 EOF
 	# NOTE: Outdated documentation, kept for when we'll reintroduce this flag.
 	# $(format_flag --offline)
@@ -69,7 +76,8 @@ help() {
 
 CARGO_CHEF_EXTRA_ARGS=()
 CARGO_INSTALL_EXTRA_ARGS=()
-unset NO_PULL CARGO_PROFILE
+CARGO_PROFILE=release
+unset NO_PULL
 
 for arg in "$@"; do
 	case $arg in
@@ -79,9 +87,8 @@ for arg in "$@"; do
 		--tag=*)
 			PROSE_POD_API_IMAGE_TAG="${arg#'--tag='}"
 			;;
-		--debug)
-			info 'Will build in debug mode.'
-			CARGO_PROFILE='dev'
+		--profile=*)
+			CARGO_PROFILE="${arg#'--profile='}"
 			;;
 		--offline)
 			die "Offline builds are not supported anymore, because we build the Rust project in a Dockerfile and we have a git dependency ($(format_code prose-core-client)). If you need this feature, consider adding $(format_code prose-core-client) as a $(format_hyperlink 'git submodule' 'https://git-scm.com/book/en/v2/Git-Tools-Submodules') instead."
@@ -96,9 +103,17 @@ for arg in "$@"; do
 			NO_PULL=1
 			;;
 		--help) help ;;
+		--dry-run) export DRY_RUN=1 ;;
+		--debug) export LOG_DEBUG=1 ;;
+		--trace) export LOG_TRACE=1 ;;
 		*) die "Unknown argument: $(format_code $arg).\n$(usage)" ;;
 	esac
 done
+
+# Recompute log levels.
+source "${BASH_TOOLBOX:?}"/log.sh
+
+info "Will build with profile $(format_code "${CARGO_PROFILE:?}")."
 
 # Regenerate image name.
 unset PROSE_POD_API_IMAGE


### PR DESCRIPTION
I tried different cargo profile configurations, and I came up with better settings to speed up all builds. I also created a `staging` profile which we will now use when building `edge`. It should be about 2 times quicker now.

Fixes #104.

Here are my benchmarks (not a source of truth, more like notes for myself):

```toml
[profile.release]
opt-level = "s"
lto = true
debug = false
debug-assertions = false
panic = "abort"
```

      594.97 real         4.13 user         5.82 sys
27.7MB

---

```toml
[profile.release]
opt-level = "s"
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
```

      605.31 real         4.33 user         5.13 sys
34.1MB

---

```toml
[profile.release]
opt-level = 2
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
```

      675.15 real         4.72 user         6.41 sys
37.9MB

---

```toml
[profile.release]
opt-level = 1
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
```

      610.94 real         4.35 user         5.50 sys
37MB

---

```toml
[profile.release]
opt-level = 0
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
```

      356.43 real         3.07 user         4.41 sys
68.5MB

---

```toml
[profile.dev]
opt-level = 0
debug = true
debug-assertions = true

[profile.staging]
inherits = "dev"
opt-level = 1
debug-assertions = false
```

---
      747.32 real         5.05 user         5.78 sys
390MB


```toml
[profile.dev]
opt-level = 0
debug = true
debug-assertions = true

[profile.staging]
inherits = "dev"
lto = "thin"
debug-assertions = false
```

      506.68 real         3.69 user         4.67 sys
301MB

---

```toml
[profile.dev]
opt-level = 0
debug = true
debug-assertions = true

[profile.staging]
inherits = "dev"
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
```

      405.74 real         3.28 user         4.44 sys
68.8MB

---

```toml
[profile.dev]
opt-level = 0
debug = true
debug-assertions = true

[profile.staging]
inherits = "dev"
lto = "thin"
debug = false
debug-assertions = false
panic = "abort"
incremental = true
```

      420.29 real         3.61 user         5.18 sys
68.8MB

---

```toml
[profile.release]
opt-level = "s"
lto = "thin"
debug = false
debug-assertions = false
strip = "symbols"
panic = "abort"
```

      591.12 real         4.19 user         5.08 sys
28.6MB

---

```toml
[profile.dev]
opt-level = 0
debug = true
debug-assertions = true
```

      318.66 real         2.88 user         3.98 sys
357MB

---

```toml
[profile.dev]
opt-level = 0
debug = false
debug-assertions = true
```

      278.41 real         2.84 user         4.12 sys
76.4MB
