### PR TITLE
feat: Allow returning detailed error responses in non-debug builds

### DIFF
--- a/crates/rest-api/src/error/mod.rs
+++ b/crates/rest-api/src/error/mod.rs
@@ -28,6 +28,8 @@ pub mod prelude {
     pub use super::{CustomErrorCode, Error, ErrorCode, HttpApiError, LogLevel};
 }
 
+pub(crate) static DETAILED_ERROR_REPONSES: AtomicBool = AtomicBool::new(false);
+
 #[derive(Debug)]
 pub struct ErrorCode {
     /// User-facing error code (a string for easier understanding).
@@ -146,7 +148,7 @@ impl Error {
     }
 
     fn as_json(&self) -> serde_json::Value {
-        if cfg!(debug_assertions) {
+        if DETAILED_ERROR_REPONSES.load(Ordering::Relaxed) {
             serde_json::to_value(self).unwrap_or_else(|_| {
                 json!({
                     "error": self.code,

--- a/crates/rest-api/src/features/startup_actions/mod.rs
+++ b/crates/rest-api/src/features/startup_actions/mod.rs
@@ -13,7 +13,7 @@ mod wait_for_server;
 
 use tracing::trace;
 
-use crate::AppState;
+use crate::{error::DETAILED_ERROR_REPONSES, AppState};
 
 use self::create_service_accounts::*;
 use self::init_server_config::*;
@@ -26,6 +26,11 @@ use self::wait_for_server::*;
 pub async fn on_startup(app_state: &AppState) -> Result<(), String> {
     trace!("Running startup actions…");
 
+    DETAILED_ERROR_REPONSES.store(
+        app_state.app_config.debug.detailed_error_responses,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+
     run_migrations(app_state).await?;
     test_services_reachability(app_state).await?;
     wait_for_server(app_state).await?;
@@ -33,5 +38,6 @@ pub async fn on_startup(app_state: &AppState) -> Result<(), String> {
     init_server_config(app_state).await?;
     register_oauth2_client(app_state).await?;
     create_service_accounts(app_state).await?;
+
     Ok(())
 }

--- a/crates/rest-api/src/main.rs
+++ b/crates/rest-api/src/main.rs
@@ -22,8 +22,9 @@ use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter, FmtSubscriber};
 #[tokio::main]
 async fn main() {
     let app_config = AppConfig::from_default_figment();
-    #[cfg(debug_assertions)]
-    dbg!(&app_config);
+    if app_config.debug.log_config_at_startup {
+        dbg!(&app_config);
+    }
 
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()

--- a/crates/service/src/features/app_config/defaults.rs
+++ b/crates/service/src/features/app_config/defaults.rs
@@ -23,6 +23,19 @@ use crate::{
 
 use super::{ConfigDatabase, ConfigServiceAccount, API_DATA_DIR};
 
+// GENERAL
+
+#[cfg(debug_assertions)]
+pub fn true_in_debug() -> bool {
+    true
+}
+#[cfg(not(debug_assertions))]
+pub fn true_in_debug() -> bool {
+    false
+}
+
+// SPECIFIC
+
 pub fn service_accounts_prose_pod_api() -> ConfigServiceAccount {
     ConfigServiceAccount {
         xmpp_node: JidNode::from_str("prose-pod-api").unwrap(),

--- a/crates/service/src/features/app_config/mod.rs
+++ b/crates/service/src/features/app_config/mod.rs
@@ -73,6 +73,8 @@ pub struct AppConfig {
     pub default_response_timeout: Duration<TimeLike>,
     #[serde(default = "defaults::default_retry_interval")]
     pub default_retry_interval: Duration<TimeLike>,
+    #[serde(default, rename = "debug_use_at_your_own_risk")]
+    pub debug: ConfigDebug,
     #[cfg(debug_assertions)]
     #[serde(default)]
     pub debug_only: ConfigDebugOnly,
@@ -314,6 +316,23 @@ pub struct ConfigDatabase {
     pub idle_timeout: Option<u64>,
     #[serde(default)]
     pub sqlx_logging: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConfigDebug {
+    #[serde(default = "defaults::true_in_debug")]
+    pub log_config_at_startup: bool,
+    #[serde(default = "defaults::true_in_debug")]
+    pub detailed_error_responses: bool,
+}
+
+impl Default for ConfigDebug {
+    fn default() -> Self {
+        Self {
+            log_config_at_startup: defaults::true_in_debug(),
+            detailed_error_responses: defaults::true_in_debug(),
+        }
+    }
 }
 
 #[cfg(debug_assertions)]

--- a/local-run/scenarios/default/Prose.toml
+++ b/local-run/scenarios/default/Prose.toml
@@ -14,6 +14,10 @@ pod_address = "pod@prose.org.local"
 smtp_host = "mailpit"
 smtp_encrypt = false
 
+[debug_use_at_your_own_risk]
+log_config_at_startup = true
+detailed_error_responses = true
+
 [debug_only]
 insecure_password_on_auto_accept_invitation = true
 


### PR DESCRIPTION
- With `debug_use_at_your_own_risk.log_config_at_startup = true`, the API will log the app configuration at startup
  - While passwords are not printed, some data could be considered sensitive which is why it's "use at your own risk"
- With `debug_use_at_your_own_risk.detailed_error_responses = true`, the API returns
  
  ```txt
  {
      "error": self.code,
      "message": self.message,
      "debug_info": self.debug_info,
  }
  ```
  
  instead of just
  
  ```txt
  {
      "error": self.code
  }
  ```

  - This should not be enabled in production as it leaks too much information about internal errors
  