### PR TITLE
Revert "chore: Update `axum` to `0.8`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,14 +236,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
+ "async-trait",
  "axum-core",
  "axum-macros",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http 1.2.0",
  "http-body",
@@ -271,10 +271,11 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures-util",
  "http 1.2.0",
@@ -291,15 +292,14 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.0"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
  "cookie",
- "form_urlencoded",
  "futures-util",
  "headers",
  "http 1.2.0",
@@ -309,7 +309,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_html_form",
- "serde_path_to_error",
  "tower",
  "tower-layer",
  "tower-service",
@@ -317,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "17.1.0"
+version = "16.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375ec4f6db373ce6d696839249203c57049aefe1213cfa77bb2e12e10ed43d08"
+checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2181,9 +2180,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.8.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -4154,9 +4153,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4171,9 +4170,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/prose-im/prose-pod-api.git"
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
 async-trait = { version = "0.1", default-features = false }
-axum = { version = "0.8", default-features = false }
-axum-extra = { version = "0.10", default-features = false }
-axum-test = { version = "17", default-features = false }
+axum = { version = "0.7", default-features = false }
+axum-extra = { version = "0.9", default-features = false }
+axum-test = { version = "16", default-features = false }
 base64 = { version = "0.22", default-features = false }
 chrono = { version = "0.4", default-features = false }
 cucumber = { version = "0.21", default-features = false }

--- a/crates/rest-api/src/features/auth/guards/auth_service.rs
+++ b/crates/rest-api/src/features/auth/guards/auth_service.rs
@@ -5,6 +5,7 @@
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::auth::AuthService {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/features/auth/guards/auth_token.rs
+++ b/crates/rest-api/src/features/auth/guards/auth_token.rs
@@ -10,6 +10,7 @@ use crate::guards::prelude::*;
 
 const PREFIX: &'static str = "Bearer ";
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::auth::auth_service::AuthToken {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/auth/guards/authenticated.rs
+++ b/crates/rest-api/src/features/auth/guards/authenticated.rs
@@ -57,6 +57,7 @@ use crate::guards::prelude::*;
 /// [`MemberService`]: service::members::MemberService
 pub struct Authenticated;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for Authenticated {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/auth/guards/basic_auth.rs
+++ b/crates/rest-api/src/features/auth/guards/basic_auth.rs
@@ -17,6 +17,7 @@ pub struct BasicAuth {
     pub password: SecretString,
 }
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for BasicAuth {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/auth/guards/is_admin.rs
+++ b/crates/rest-api/src/features/auth/guards/is_admin.rs
@@ -13,6 +13,7 @@ use crate::guards::prelude::*;
 /// but it'll do for now.
 pub struct IsAdmin;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for IsAdmin {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/auth/guards/user_info.rs
+++ b/crates/rest-api/src/features/auth/guards/user_info.rs
@@ -7,6 +7,7 @@ use service::auth::auth_service::AuthToken;
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::auth::UserInfo {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/init/guards/init_service.rs
+++ b/crates/rest-api/src/features/init/guards/init_service.rs
@@ -5,6 +5,7 @@
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::init::InitService {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/features/invitations/guards/invitation_service.rs
+++ b/crates/rest-api/src/features/invitations/guards/invitation_service.rs
@@ -7,6 +7,7 @@ use service::members::UnauthenticatedMemberService;
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::invitations::InvitationService {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/features/invitations/mod.rs
+++ b/crates/rest-api/src/features/invitations/mod.rs
@@ -37,20 +37,20 @@ pub(super) fn router(app_state: AppState) -> axum::Router {
                         .get(get_invitations_route),
                 )
                 .route(
-                    "/{invitation_id}",
+                    "/:invitation_id",
                     MethodRouter::new()
                         .get(get_invitation_route)
                         .delete(invitation_cancel_route),
                 )
-                .route("/{invitation_id}/resend", post(invitation_resend_route))
+                .route("/:invitation_id/resend", post(invitation_resend_route))
                 .route_layer(from_extractor_with_state::<IsAdmin, _>(app_state.clone())),
         )
         .nest(
             "/v1/invitation-tokens",
             axum::Router::new()
-                .route("/{token}/details", get(get_invitation_by_token_route))
-                .route("/{token}/accept", put(invitation_accept_route))
-                .route("/{token}/reject", put(invitation_reject_route)),
+                .route("/:token/details", get(get_invitation_by_token_route))
+                .route("/:token/accept", put(invitation_accept_route))
+                .route("/:token/reject", put(invitation_reject_route)),
         )
         .with_state(app_state)
 }

--- a/crates/rest-api/src/features/members/guards/member_service.rs
+++ b/crates/rest-api/src/features/members/guards/member_service.rs
@@ -7,6 +7,7 @@ use service::{auth::UserInfo, members::MemberServiceContext, xmpp::XmppService};
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::members::MemberService {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/features/members/guards/unauthenticated_member_service.rs
+++ b/crates/rest-api/src/features/members/guards/unauthenticated_member_service.rs
@@ -5,6 +5,7 @@
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::members::UnauthenticatedMemberService {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/features/members/mod.rs
+++ b/crates/rest-api/src/features/members/mod.rs
@@ -28,7 +28,7 @@ pub use self::get_members::*;
 pub use self::model::*;
 
 pub(crate) const MEMBERS_ROUTE: &'static str = "/v1/members";
-pub(crate) const MEMBER_ROUTE: &'static str = "/v1/members/{jid}";
+pub(crate) const MEMBER_ROUTE: &'static str = "/v1/members/:jid";
 
 pub(super) fn router(app_state: AppState) -> axum::Router {
     axum::Router::new()
@@ -43,9 +43,9 @@ pub(super) fn router(app_state: AppState) -> axum::Router {
             MEMBERS_ROUTE,
             axum::Router::new()
                 .route("/", get(get_members_route))
-                .route("/{jid}", get(get_member_route))
+                .route("/:jid", get(get_member_route))
                 .route(
-                    "/{jid}",
+                    "/:jid",
                     delete(delete_member_route)
                         .route_layer(from_extractor_with_state::<IsAdmin, _>(app_state.clone())),
                 ),

--- a/crates/rest-api/src/features/network_checks/guards/network_checker.rs
+++ b/crates/rest-api/src/features/network_checks/guards/network_checker.rs
@@ -7,6 +7,7 @@ use service::network_checks::NetworkChecker;
 
 use crate::guards::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for NetworkChecker {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/features/workspace_details/guards/workspace_service.rs
+++ b/crates/rest-api/src/features/workspace_details/guards/workspace_service.rs
@@ -10,6 +10,7 @@ use service::{
 
 use crate::{error::prelude::*, guards::prelude::*};
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for WorkspaceService {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/guards/app_config.rs
+++ b/crates/rest-api/src/guards/app_config.rs
@@ -5,6 +5,7 @@
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::AppConfig {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/guards/notification_service.rs
+++ b/crates/rest-api/src/guards/notification_service.rs
@@ -5,6 +5,7 @@
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::notifications::NotificationService {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/guards/pod_network_config.rs
+++ b/crates/rest-api/src/guards/pod_network_config.rs
@@ -12,6 +12,7 @@ use crate::features::init::PodAddressNotInitialized;
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::network_checks::PodNetworkConfig {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/guards/secrets_store.rs
+++ b/crates/rest-api/src/guards/secrets_store.rs
@@ -5,6 +5,7 @@
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::secrets::SecretsStore {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/guards/server_config.rs
+++ b/crates/rest-api/src/guards/server_config.rs
@@ -9,6 +9,7 @@ use crate::features::init::ServerConfigNotInitialized;
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for server_config::Model {
     type Rejection = error::Error;
 
@@ -23,6 +24,7 @@ impl FromRequestParts<AppState> for server_config::Model {
     }
 }
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::server_config::ServerConfig {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/guards/server_ctl.rs
+++ b/crates/rest-api/src/guards/server_ctl.rs
@@ -5,6 +5,7 @@
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::xmpp::ServerCtl {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/guards/server_manager.rs
+++ b/crates/rest-api/src/guards/server_manager.rs
@@ -7,6 +7,7 @@ use service::server_config::entities::server_config;
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::xmpp::ServerManager {
     type Rejection = error::Error;
 

--- a/crates/rest-api/src/guards/uuid_generator.rs
+++ b/crates/rest-api/src/guards/uuid_generator.rs
@@ -5,6 +5,7 @@
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for service::dependencies::Uuid {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/guards/xmpp_service.rs
+++ b/crates/rest-api/src/guards/xmpp_service.rs
@@ -10,6 +10,7 @@ use service::{
 
 use super::prelude::*;
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for XmppService {
     type Rejection = error::Error;
 
@@ -28,6 +29,7 @@ impl FromRequestParts<AppState> for XmppService {
     }
 }
 
+#[async_trait::async_trait]
 impl FromRequestParts<AppState> for XmppServiceInner {
     type Rejection = Infallible;
 

--- a/crates/rest-api/src/util/content_type_or.rs
+++ b/crates/rest-api/src/util/content_type_or.rs
@@ -76,6 +76,7 @@ where
 
 pub struct WithContentType<C>(PhantomData<C>);
 
+#[async_trait::async_trait]
 impl<S, C> FromRequestParts<S> for WithContentType<C>
 where
     C: ContentType,


### PR DESCRIPTION
Release builds have been broken since this commit. amd64 builds work (integration tests pass), but arm64 builds fail because of a segmentation fault 🤨 Let's just revert, we didn't **need** the bump. Hopefully next time we try bumping the issue will have been fixed.

(I haven't submitted a bug report, I don't have time for it right now.)

This reverts commit 36458aa961ed41fb31ffdaf27bab37b30871f24a.

Reopens #115.

Fixes #160.