### PR TITLE
fix(auth): Return `401`s when tokens expire (not `403s`)

### DIFF
--- a/crates/rest-api/src/features/auth/guards/user_info.rs
+++ b/crates/rest-api/src/features/auth/guards/user_info.rs
@@ -21,7 +21,7 @@ impl FromRequestParts<AppState> for service::auth::UserInfo {
             .get_user_info(token)
             .await
             .map_err(|err| {
-                Error::from(error::Forbidden(format!(
+                Error::from(error::Unauthorized(format!(
                     "Could not get user info from token: {err}"
                 )))
             })

--- a/crates/service/src/features/app_config/defaults.rs
+++ b/crates/service/src/features/app_config/defaults.rs
@@ -83,6 +83,10 @@ pub fn server_oauth2_registration_key() -> SecretString {
     SecretString::new(bytes_to_base64(&key))
 }
 
+pub fn server_oauth2_access_token_ttl() -> u32 {
+    10800
+}
+
 /// Enable message archiving by default.
 pub fn server_defaults_message_archive_enabled() -> bool {
     true

--- a/crates/service/src/features/app_config/mod.rs
+++ b/crates/service/src/features/app_config/mod.rs
@@ -161,6 +161,8 @@ pub struct ConfigServer {
     pub prosody_config_file_path: PathBuf,
     #[serde(default = "defaults::server_oauth2_registration_key")]
     pub oauth2_registration_key: SecretString,
+    #[serde(default = "defaults::server_oauth2_access_token_ttl")]
+    pub oauth2_access_token_ttl: u32,
     #[serde(default)]
     pub defaults: ConfigServerDefaults,
 }
@@ -194,6 +196,7 @@ impl Default for ConfigServer {
             http_port: defaults::server_http_port(),
             prosody_config_file_path: defaults::server_prosody_config_file_path(),
             oauth2_registration_key: defaults::server_oauth2_registration_key(),
+            oauth2_access_token_ttl: defaults::server_oauth2_access_token_ttl(),
             defaults: Default::default(),
         }
     }

--- a/crates/service/src/features/prosody/prosody_config_from_db.rs
+++ b/crates/service/src/features/prosody/prosody_config_from_db.rs
@@ -272,7 +272,10 @@ impl ProseDefault for prosody_config::ProsodyConfig {
                                             "password",
                                         ],
                                     ),
-                                    def("oauth2_access_token_ttl", 10800),
+                                    def(
+                                        "oauth2_access_token_ttl",
+                                        app_config.server.oauth2_access_token_ttl,
+                                    ),
                                     // We don't want tokens to be refreshed
                                     def("oauth2_refresh_token_ttl", 0),
                                     def(

--- a/crates/service/src/features/prosody/prosody_rest.rs
+++ b/crates/service/src/features/prosody/prosody_rest.rs
@@ -160,13 +160,13 @@ impl ConnectionTrait for Connection {
                 trace!("response_body: {response_body:?}");
                 let xml = format!(r#"<wrapper xmlns="jabber:client">{response_body}</wrapper>"#);
                 let wrapper = xml.parse::<Element>()?;
-                let stanza = wrapper
-                    .get_child("iq", "jabber:client")
-                    .expect(&format!(
-                        "Prosody response is not an `iq` stanza (`{response_body}`).",
-                    ))
-                    .to_owned();
-                self.receive_stanza(stanza).await;
+                let Some(stanza) = wrapper.get_child("iq", "jabber:client") else {
+                    // TODO: Handle "not-authorized".
+                    return Err(anyhow!(
+                        "Prosody response is not an `iq` stanza (`{response_body}`)."
+                    ));
+                };
+                self.receive_stanza(stanza.to_owned()).await;
                 Result::<_, anyhow::Error>::Ok(())
             })
         })?;

--- a/crates/service/src/features/xmpp/xmpp_service.rs
+++ b/crates/service/src/features/xmpp/xmpp_service.rs
@@ -207,7 +207,7 @@ pub type Error = XmppServiceError;
 pub enum XmppServiceError {
     #[error("Connection error: {0}")]
     ConnectionError(#[from] ConnectionError),
-    #[error("Request error: {0}")]
+    #[error("{0}")]
     RequestError(#[from] RequestError),
     #[error("{0}")]
     Other(String),

--- a/features/members/members-list.feature
+++ b/features/members/members-list.feature
@@ -52,7 +52,7 @@ Feature: Members list
 
     Scenario Outline: Bad token
       When someone lists members using <token> as Bearer token
-      Then the HTTP status code should be Forbidden
+      Then the HTTP status code should be Unauthorized
 
     Examples:
       | token |

--- a/local-run/scripts/constants.sh
+++ b/local-run/scripts/constants.sh
@@ -2,7 +2,7 @@
 #   It avoids resetting a variable when sourcing this file after the variable was overriden.
 
 : ${PROSE_POD_API_IMAGE_TAG:=0.8.1}
-: ${PROSE_POD_SERVER_IMAGE_TAG:=0.3.5}
+: ${PROSE_POD_SERVER_IMAGE_TAG:=0.3.7}
 LOCAL_RUN_DIR="${PROSE_POD_API_DIR:?}"/local-run
 : ${COMPOSE_FILE:="${LOCAL_RUN_DIR:?}"/compose.yaml}
 DEFAULT_SCENARIO_NAME=default

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -68,7 +68,8 @@ stop() {
 }
 
 abort() {
-	stop
+	# Do not stop the API after a failure to allow investigation.
+	# NOTE: In the CI, it will be stopped anyway so it’s perfect.
 	task integration-test:logs
 	exit 1
 }
@@ -82,6 +83,7 @@ stepci_run() {
 	info "${Blue}$(for _ in $(seq 72); do printf "="; done)${Color_Off}"
 
 	export PROSE_CONFIG_FILE="${INTEGRATION_TESTS_DIR:?}/Prose-${config_options:?}.toml"
+	[ -f "${PROSE_CONFIG_FILE:?}" ] || die "File $(format_url "${PROSE_CONFIG_FILE:?}") doesn't exist."
 	# NOTE: We have to `cd $STEPCI_DIR` because transitive `$ref`s are not processed correctly otherwise.
 	start && \
 	{ (cd "${STEPCI_DIR:?}" && edo stepci run "${test_file#"${STEPCI_DIR:?}/"}" --env host="${INTEGRATION_TEST_HOST:?}") \
@@ -110,6 +112,8 @@ for arg in "$@"; do
 			DNS_ZONE_FILE="${DNS_ZONES_DIR:?}"/working-dynamic.zone stepci_run "$test_file" ;;
 		*dns-configured-correctly-static)
 			DNS_ZONE_FILE="${DNS_ZONES_DIR:?}"/working-static.zone stepci_run "$test_file" ;;
+		auth-expired)
+			stepci_run "$test_file" 'tokens-expired' ;;
 		init)
 			SCENARIO_NAME=fresh stepci_run "$test_file" ;;
 		*)

--- a/tests/integration/Prose-tokens-expired.toml
+++ b/tests/integration/Prose-tokens-expired.toml
@@ -1,0 +1,22 @@
+# Prose Pod API
+# REST API for administrating a Prose Pod
+# Configuration file
+# Example: https://github.com/prose-im/prose-pod-system/blob/master/Prose-example.toml
+# All keys: https://github.com/prose-im/prose-pod-api/blob/master/crates/service/src/features/app_config/mod.rs
+
+[branding]
+page_url = "http://admin.prose.org.local/"
+company_name = "Prose Test"
+
+[notify.email]
+pod_address = "pod@prose.org.local"
+
+smtp_host = "mailpit"
+smtp_encrypt = false
+
+[server]
+# Expire tokens immediately, allowing successful log in but not subsequent requests.
+oauth2_access_token_ttl = 0
+
+[debug_only]
+insecure_password_on_auto_accept_invitation = true

--- a/tests/integration/step-ci/auth-expired.yaml
+++ b/tests/integration/step-ci/auth-expired.yaml
@@ -1,0 +1,27 @@
+version: "1.1"
+name: Authentication (tokens expiring after 1 second)
+config:
+  http:
+    baseURL: ${{ env.host }}
+env:
+  $ref: "env.yaml#/env"
+
+# NOTE: Paths are relative to the directory from which `stepci` is ran.
+tests:
+  # See [When a token expires, routes return `403` instead of `401` · Issue #171 · prose-im/prose-pod-api](https://github.com/prose-im/prose-pod-api/issues/171).
+  expiredTokenYieldsUnauthenticated:
+    name: Using an expired token yields 401 Unauthorized
+    steps:
+      - $ref: "init.yaml#/components/steps/log_admin_in"
+      - http:
+          method: GET
+          url: /v1/members
+          auth:
+            bearer:
+              token: ${{ captures.token }}
+          check:
+            status: 401
+            headers:
+              Content-Type: application/json
+            schema:
+              $ref: openapi.json#/components/schemas/Error


### PR DESCRIPTION
Fixes #171.