### PR TITLE
feat!: Use status code `412` instead of `400` when things are not initialized

### DIFF
--- a/crates/rest-api/src/features/init/init_server_config.rs
+++ b/crates/rest-api/src/features/init/init_server_config.rs
@@ -52,7 +52,7 @@ pub async fn init_server_config_route(
 impl ErrorCode {
     pub const SERVER_CONFIG_NOT_INITIALIZED: Self = Self {
         value: "server_config_not_initialized",
-        http_status: StatusCode::BAD_REQUEST,
+        http_status: StatusCode::PRECONDITION_FAILED,
         log_level: LogLevel::Warn,
     };
     pub const SERVER_CONFIG_ALREADY_INITIALIZED: Self = Self {
@@ -62,7 +62,7 @@ impl ErrorCode {
     };
     pub const POD_ADDRESS_NOT_INITIALIZED: Self = Self {
         value: "pod_address_not_initialized",
-        http_status: StatusCode::BAD_REQUEST,
+        http_status: StatusCode::PRECONDITION_FAILED,
         log_level: LogLevel::Warn,
     };
 }

--- a/crates/rest-api/src/features/init/init_workspace.rs
+++ b/crates/rest-api/src/features/init/init_workspace.rs
@@ -69,7 +69,7 @@ pub async fn init_workspace_route(
 impl ErrorCode {
     pub const WORKSPACE_NOT_INITIALIZED: Self = Self {
         value: "workspace_not_initialized",
-        http_status: StatusCode::BAD_REQUEST,
+        http_status: StatusCode::PRECONDITION_FAILED,
         log_level: LogLevel::Warn,
     };
     pub const WORKSPACE_ALREADY_INITIALIZED: Self = Self {

--- a/crates/rest-api/static/api-docs/features/dns-setup.yaml
+++ b/crates/rest-api/static/api-docs/features/dns-setup.yaml
@@ -14,7 +14,7 @@ paths:
         content:
           application/json:
             schema: { $ref: "#/components/schemas/GetDnsRecordsResponse" }
-      "400": { $ref: "pod-config.yaml#/components/responses/PodAddressNotInitialized" }
+      "412": { $ref: "pod-config.yaml#/components/responses/PodAddressNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
 components:

--- a/crates/rest-api/static/api-docs/features/init.yaml
+++ b/crates/rest-api/static/api-docs/features/init.yaml
@@ -31,7 +31,7 @@ paths:
             schema: { $ref: "members.yaml#/components/schemas/Member" }
         headers:
           Location: { $ref: "../shared.yaml#/components/headers/Location" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "409":
         description: First account already created
         content:

--- a/crates/rest-api/static/api-docs/features/invitations.yaml
+++ b/crates/rest-api/static/api-docs/features/invitations.yaml
@@ -49,7 +49,7 @@ paths:
             schema: { $ref: "#/components/schemas/WorkspaceInvitation" }
         headers:
           Location: { $ref: "../shared.yaml#/components/headers/Location" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   get_invitations:
@@ -110,7 +110,7 @@ paths:
         content:
           application/json:
             schema: { $ref: "#/components/schemas/WorkspaceInvitation" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
       "404": { $ref: "../shared.yaml#/components/responses/NotFound" }
@@ -125,7 +125,7 @@ paths:
       - $ref: "#/components/parameters/InvitationId"
     responses:
       "204": { $ref: "../shared.yaml#/components/responses/NoContent" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   get_invitation_token_details:
@@ -146,7 +146,7 @@ paths:
         content:
           application/json:
             schema: { $ref: "#/components/schemas/WorkspaceInvitationBasicDetails" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   invitation_accept:
@@ -171,7 +171,7 @@ paths:
               password: { $ref: "../shared.yaml#/components/schemas/Password" }
     responses:
       "204": { $ref: "../shared.yaml#/components/responses/NoContent" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "410": { $ref: "../shared.yaml#/components/responses/Gone" }
   invitation_reject:
     tags: [Invitations]
@@ -183,7 +183,7 @@ paths:
       - $ref: "#/components/parameters/InvitationRejectToken"
     responses:
       "204": { $ref: "../shared.yaml#/components/responses/NoContent" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "410": { $ref: "../shared.yaml#/components/responses/Gone" }
   invitation_resend:
     tags: [Invitations]
@@ -200,7 +200,7 @@ paths:
         content:
           application/json:
             schema: { $ref: "#/components/schemas/WorkspaceInvitation" }
-      "400": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "server-config.yaml#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
 components:

--- a/crates/rest-api/static/api-docs/features/pod-config.yaml
+++ b/crates/rest-api/static/api-docs/features/pod-config.yaml
@@ -68,7 +68,7 @@ paths:
         content:
           application/json:
             schema: { $ref: "#/components/schemas/PodAddress" }
-      "400": { $ref: "#/components/responses/PodAddressNotInitialized" }
+      "412": { $ref: "#/components/responses/PodAddressNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
 components:

--- a/crates/rest-api/static/api-docs/features/server-config.yaml
+++ b/crates/rest-api/static/api-docs/features/server-config.yaml
@@ -35,7 +35,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_file_upload_allowed:
@@ -58,7 +58,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_file_storage_retention:
@@ -83,7 +83,7 @@ paths:
                   - $ref: "../shared.yaml#/components/schemas/DurationInfinite"
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_file_storage_encryption_scheme:
@@ -95,7 +95,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_messaging_config:
@@ -107,7 +107,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_message_archive_retention:
@@ -132,7 +132,7 @@ paths:
                   - $ref: "../shared.yaml#/components/schemas/DurationInfinite"
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_message_archive_retention:
@@ -144,7 +144,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_files_config:
@@ -156,7 +156,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_message_archive_enabled:
@@ -179,7 +179,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_push_notifications_config:
@@ -191,7 +191,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_push_notification_with_body:
@@ -203,7 +203,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_push_notification_with_body:
@@ -228,7 +228,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_push_notification_with_sender:
@@ -240,7 +240,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_push_notification_with_sender:
@@ -265,7 +265,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_network_encryption_config:
@@ -277,7 +277,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_tls_profile:
@@ -289,7 +289,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_tls_profile:
@@ -313,7 +313,7 @@ paths:
               tls_profile: { $ref: "#/components/schemas/TlsProfile" }
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_server_federation_config:
@@ -325,7 +325,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_federation_enabled:
@@ -337,7 +337,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_federation_enabled:
@@ -363,7 +363,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_federation_whitelist_enabled:
@@ -375,7 +375,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_federation_whitelist_enabled:
@@ -400,7 +400,7 @@ paths:
                 type: boolean
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   reset_federation_friendly_servers:
@@ -412,7 +412,7 @@ paths:
       - BearerAuth: []
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
   set_federation_friendly_servers:
@@ -441,7 +441,7 @@ paths:
                   format: domain-name
     responses:
       "200": { $ref: "#/components/responses/ServerConfig" }
-      "400": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
       "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
       "403": { $ref: "../shared.yaml#/components/responses/Forbidden" }
 components:
@@ -540,6 +540,14 @@ components:
       type: string
       enum: [modern, intermediate, old]
       default: modern
+    ServerConfigNotInitialized:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          const: server_config_not_initialized
   responses:
     ServerConfig:
       description: Success
@@ -557,6 +565,4 @@ components:
       description: XMPP server not initialized
       content:
         application/json:
-          schema: { $ref: "../shared.yaml#/components/schemas/Error" }
-          example:
-            error: server_config_not_initialized
+          schema: { $ref: "#/components/schemas/ServerConfigNotInitialized" }

--- a/crates/rest-api/tests/cucumber_parameters/http_status.rs
+++ b/crates/rest-api/tests/cucumber_parameters/http_status.rs
@@ -26,6 +26,7 @@ impl FromStr for HTTPStatus {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(HTTPStatus(match s {
             "BadRequest" | "Bad Request" => StatusCode::BAD_REQUEST,
+            "PreconditionFailed" | "Precondition Failed" => StatusCode::PRECONDITION_FAILED,
             "Unauthorized" => StatusCode::UNAUTHORIZED,
             "Forbidden" => StatusCode::FORBIDDEN,
             "Ok" | "OK" => StatusCode::OK,

--- a/crates/rest-api/tests/features/init.rs
+++ b/crates/rest-api/tests/features/init.rs
@@ -154,7 +154,7 @@ async fn then_error_reason(world: &mut TestWorld, reason: String) -> Result<(), 
 #[then("the user should receive 'Workspace not initialized'")]
 async fn then_error_workspace_not_initialized(world: &mut TestWorld) {
     let res = world.result();
-    res.assert_status(StatusCode::BAD_REQUEST);
+    res.assert_status(StatusCode::PRECONDITION_FAILED);
     assert_eq!(
         res.header(CONTENT_TYPE),
         "application/json",
@@ -184,7 +184,7 @@ async fn then_error_workspace_already_initialized(world: &mut TestWorld) {
 #[then("the user should receive 'Server config not initialized'")]
 async fn then_error_server_config_not_initialized(world: &mut TestWorld) {
     let res = world.result();
-    res.assert_status(StatusCode::BAD_REQUEST);
+    res.assert_status(StatusCode::PRECONDITION_FAILED);
     assert_eq!(
         res.header(CONTENT_TYPE),
         "application/json",

--- a/features/dns-setup.feature
+++ b/features/dns-setup.feature
@@ -144,5 +144,5 @@ Feature: DNS setup instructions
     Scenario: Prose Pod address not initialized
       Given the Prose Pod address has not been initialized
        When Valerian requests DNS setup instructions
-       Then the HTTP status code should be Bad Request
+       Then the HTTP status code should be Precondition Failed
         And the error code should be "pod_address_not_initialized"


### PR DESCRIPTION
We don't support caching yet, but `400` wasn't semantically correct. One day we will require `If-None-Match: *` on the affected routes. One thing at a time.

NOTE: This is ground work for the next commit regarding #174.