### PR TITLE
feat: Add `HEAD /v1/server/config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Copyright 2022-2024, Prose Foundation - Released under the [Mozilla Public License 2.0](./LICENSE.md).
 
-_Tested at Rust version: `rustc 1.84.0 (9fc6b4312 2025-01-07)`_
+_Tested at Rust version: `rustc 1.84.1 (e71f9a9a9 2025-01-27) (Homebrew)`_
 
 ## License
 

--- a/crates/rest-api/src/error/errors.rs
+++ b/crates/rest-api/src/error/errors.rs
@@ -120,6 +120,24 @@ impl HttpApiError for BadRequest {
 }
 
 impl ErrorCode {
+    pub const PRECONDITION_REQUIRED: Self = Self {
+        value: "precondition_required",
+        http_status: StatusCode::PRECONDITION_REQUIRED,
+        log_level: LogLevel::Info,
+    };
+}
+#[derive(Debug, thiserror::Error)]
+#[error("Precondition required: {comment}")]
+pub struct PreconditionRequired {
+    pub comment: String,
+}
+impl HttpApiError for PreconditionRequired {
+    fn code(&self) -> ErrorCode {
+        ErrorCode::PRECONDITION_REQUIRED
+    }
+}
+
+impl ErrorCode {
     pub const NOT_FOUND: Self = Self {
         value: "not_found",
         http_status: StatusCode::NOT_FOUND,

--- a/crates/rest-api/src/features/server_config/get_server_config.rs
+++ b/crates/rest-api/src/features/server_config/get_server_config.rs
@@ -3,13 +3,33 @@
 // Copyright: 2023–2025, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use axum::Json;
-use service::server_config::ServerConfig;
+use axum::{extract::State, http::header::IF_NONE_MATCH, response::NoContent, Json};
+use axum_extra::{headers::IfNoneMatch, TypedHeader};
+use service::server_config::{ServerConfig, ServerConfigRepository};
 
-use crate::error::Error;
+use crate::{
+    error::{Error, PreconditionRequired},
+    features::init::ServerConfigNotInitialized,
+    AppState,
+};
 
 pub async fn get_server_config_route(
     server_config: ServerConfig,
 ) -> Result<Json<ServerConfig>, Error> {
     Ok(Json(server_config))
+}
+
+pub async fn is_server_initialized_route(
+    State(AppState { db, .. }): State<AppState>,
+    TypedHeader(if_none_match): TypedHeader<IfNoneMatch>,
+) -> Result<NoContent, Error> {
+    if if_none_match != IfNoneMatch::any() {
+        Err(Error::from(PreconditionRequired {
+            comment: format!("Missing header: '{IF_NONE_MATCH}'."),
+        }))
+    } else if ServerConfigRepository::is_initialized(&db).await? {
+        Ok(NoContent)
+    } else {
+        Err(Error::from(ServerConfigNotInitialized))
+    }
 }

--- a/crates/rest-api/src/features/server_config/mod.rs
+++ b/crates/rest-api/src/features/server_config/mod.rs
@@ -13,7 +13,7 @@ mod util;
 
 use axum::{
     middleware::from_extractor_with_state,
-    routing::{get, put},
+    routing::{get, head, put},
 };
 
 pub use file_upload::*;
@@ -112,8 +112,11 @@ pub(super) fn router(app_state: AppState) -> axum::Router {
                 .route(
                     "/federation-friendly-servers",
                     put(set_federation_friendly_servers_route),
-                ),
+                )
+                // Require authentication
+                .route_layer(from_extractor_with_state::<IsAdmin, _>(app_state.clone())),
         )
-        .route_layer(from_extractor_with_state::<IsAdmin, _>(app_state.clone()))
+        // NOTE: `HEAD /v1/server/config` doesn’t require authentication.
+        .route(SERVER_CONFIG_ROUTE, head(is_server_initialized_route))
         .with_state(app_state)
 }

--- a/crates/rest-api/static/api-docs/features/server-config.yaml
+++ b/crates/rest-api/static/api-docs/features/server-config.yaml
@@ -1,4 +1,22 @@
 paths:
+  is_server_initialized:
+    tags: [Init]
+    summary: Is the XMPP server initialized?
+    description: Query whether or not the XMPP server has already been initialized.
+    operationId: is_server_initialized
+    security: []
+    parameters:
+      - in: header
+        name: If-None-Match
+        schema:
+          type: string
+          const: "*"
+        required: true
+    responses:
+      "204":
+        description: XMPP server initialized
+      "412": { $ref: "#/components/responses/ServerConfigNotInitialized" }
+      "428": { $ref: "../shared.yaml#/components/responses/PreconditionRequired" }
   init_server_config:
     tags: [Init]
     summary: Initialize the XMPP server

--- a/crates/rest-api/static/api-docs/openapi.yaml
+++ b/crates/rest-api/static/api-docs/openapi.yaml
@@ -18,6 +18,7 @@ paths:
   "/v1/login":
     post: { $ref: "features/auth.yaml#/paths/login" }
   "/v1/server/config":
+    head: { $ref: "features/server-config.yaml#/paths/is_server_initialized" }
     get: { $ref: "features/server-config.yaml#/paths/get_server_config" }
     put: { $ref: "features/server-config.yaml#/paths/init_server_config" }
   "/v1/server/config/file-upload-allowed":

--- a/crates/rest-api/static/api-docs/shared.yaml
+++ b/crates/rest-api/static/api-docs/shared.yaml
@@ -173,6 +173,18 @@ components:
           schema: { $ref: "#/components/schemas/Error" }
           example:
             error: unknown
+    PreconditionRequired:
+      description: Precondition required (check the docs to see which precondition)
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - error
+            properties:
+              error:
+                type: string
+                const: precondition_required
   parameters:
     JidArray:
       description: A list of JIDs (as defined by [RFC 6120, section

--- a/crates/rest-api/tests/cucumber_parameters/http_status.rs
+++ b/crates/rest-api/tests/cucumber_parameters/http_status.rs
@@ -27,6 +27,7 @@ impl FromStr for HTTPStatus {
         Ok(HTTPStatus(match s {
             "BadRequest" | "Bad Request" => StatusCode::BAD_REQUEST,
             "PreconditionFailed" | "Precondition Failed" => StatusCode::PRECONDITION_FAILED,
+            "PreconditionRequired" | "Precondition Required" => StatusCode::PRECONDITION_REQUIRED,
             "Unauthorized" => StatusCode::UNAUTHORIZED,
             "Forbidden" => StatusCode::FORBIDDEN,
             "Ok" | "OK" => StatusCode::OK,

--- a/crates/service/src/features/server_config/server_config_repository.rs
+++ b/crates/service/src/features/server_config/server_config_repository.rs
@@ -13,6 +13,10 @@ use crate::{
 pub enum ServerConfigRepository {}
 
 impl ServerConfigRepository {
+    pub async fn is_initialized(db: &impl ConnectionTrait) -> Result<bool, DbErr> {
+        Ok(Entity::find().count(db).await? > 0)
+    }
+
     pub async fn create(
         db: &impl ConnectionTrait,
         form: impl Into<ServerConfigCreateForm>,

--- a/tests/integration/step-ci/init.yaml
+++ b/tests/integration/step-ci/init.yaml
@@ -10,10 +10,32 @@ tests:
   initialize:
     name: Initialize Prose Pod
     steps:
+      - name: Query the REST API to see that the server is not initialized (missing precondition)
+        http:
+          method: HEAD
+          url: /v1/server/config
+          check:
+            status: 428
+      - name: Query the REST API to see that the server is not initialized
+        http:
+          method: HEAD
+          url: /v1/server/config
+          headers:
+            If-None-Match: "*"
+          check:
+            status: 412
       - $ref: "#/components/steps/init_server"
       - $ref: "#/components/steps/init_workspace"
       - $ref: "#/components/steps/create_first_admin"
       - $ref: "#/components/steps/log_admin_in"
+      - name: Query the REST API to see that the server is initialized
+        http:
+          method: HEAD
+          url: /v1/server/config
+          headers:
+            If-None-Match: "*"
+          check:
+            status: 204
 
 components:
   steps:


### PR DESCRIPTION
Fixes #174.

Answering `412` without a precondition in the request would have been incorrect, therefore the route requires `If-None-Match: *` to work properly. Otherwise, it returns `428`.

When we will support caching, we will remove the `If-None-Match: *` requirement, but for now it's the correct way to do it.

Since it's a `HEAD` request there is no response body with error details, which is why using status codes semantically was a requirement here.