### PR TITLE
Set Workspace vCard kind to ‘application’

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "prose-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/prose-im/prose-core-client.git?rev=113c2a478598038a8e5beef4f6a7e7f47cb086c2#113c2a478598038a8e5beef4f6a7e7f47cb086c2"
+source = "git+https://github.com/prose-im/prose-core-client.git?rev=6114b744cb3e335f904bace6aeddd8a4099fdd00#6114b744cb3e335f904bace6aeddd8a4099fdd00"
 dependencies = [
  "convert_case",
  "quote",
@@ -2898,12 +2898,12 @@ dependencies = [
 [[package]]
 name = "prose-utils"
 version = "0.1.0"
-source = "git+https://github.com/prose-im/prose-core-client.git?rev=113c2a478598038a8e5beef4f6a7e7f47cb086c2#113c2a478598038a8e5beef4f6a7e7f47cb086c2"
+source = "git+https://github.com/prose-im/prose-core-client.git?rev=6114b744cb3e335f904bace6aeddd8a4099fdd00#6114b744cb3e335f904bace6aeddd8a4099fdd00"
 
 [[package]]
 name = "prose-wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/prose-im/prose-core-client.git?rev=113c2a478598038a8e5beef4f6a7e7f47cb086c2#113c2a478598038a8e5beef4f6a7e7f47cb086c2"
+source = "git+https://github.com/prose-im/prose-core-client.git?rev=6114b744cb3e335f904bace6aeddd8a4099fdd00#6114b744cb3e335f904bace6aeddd8a4099fdd00"
 dependencies = [
  "futures",
  "gloo-timers",
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "prose-xmpp"
 version = "0.1.0"
-source = "git+https://github.com/prose-im/prose-core-client.git?rev=113c2a478598038a8e5beef4f6a7e7f47cb086c2#113c2a478598038a8e5beef4f6a7e7f47cb086c2"
+source = "git+https://github.com/prose-im/prose-core-client.git?rev=6114b744cb3e335f904bace6aeddd8a4099fdd00#6114b744cb3e335f904bace6aeddd8a4099fdd00"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rustls = { version = "0.23", default-features = false }
 # `prose-xmpp` and its dependencies.
 # NOTE: See <https://github.com/prose-im/prose-core-client/blob/master/Cargo.toml>
 #   for up-to-date versions (make sure to switch to the appropriate tag).
-prose-xmpp = { git = "https://github.com/prose-im/prose-core-client.git", rev = "113c2a478598038a8e5beef4f6a7e7f47cb086c2", default-features = false }
+prose-xmpp = { git = "https://github.com/prose-im/prose-core-client.git", rev = "6114b744cb3e335f904bace6aeddd8a4099fdd00", default-features = false }
 jid = { version = "0.11", default-features = false }
 minidom = { version = "0.16", default-features = false }
 xmpp-parsers = { version = "0.21", default-features = false }

--- a/src/service/src/features/workspace/models/workspace.rs
+++ b/src/service/src/features/workspace/models/workspace.rs
@@ -51,6 +51,7 @@ impl From<Workspace> for VCard4 {
     ) -> Self {
         Self {
             fn_: vec![vcard4::Fn_ { value: name }],
+            kind: Some(vcard4::Kind::Application),
             unknown_properties: vec![accent_color
                 .as_ref()
                 .map(|c| (ACCENT_COLOR_EXTENSION_KEY, c.as_str()))]

--- a/src/service/src/features/workspace/models/workspace.rs
+++ b/src/service/src/features/workspace/models/workspace.rs
@@ -51,6 +51,7 @@ impl From<Workspace> for VCard4 {
     ) -> Self {
         Self {
             fn_: vec![vcard4::Fn_ { value: name }],
+            // See [RFC 6473: vCard KIND:application](https://www.rfc-editor.org/rfc/rfc6473.html).
             kind: Some(vcard4::Kind::Application),
             unknown_properties: vec![accent_color
                 .as_ref()

--- a/src/service/src/features/workspace/models/workspace.rs
+++ b/src/service/src/features/workspace/models/workspace.rs
@@ -57,10 +57,6 @@ impl From<Workspace> for VCard4 {
                 .map(|c| (ACCENT_COLOR_EXTENSION_KEY, c.as_str()))]
             .into_iter()
             .flatten()
-            .chain(vec![
-                // See [RFC 6350 - vCard Format Specification, section 6.1.4](https://datatracker.ietf.org/doc/html/rfc6350#section-6.1.4).
-                ("kind", "org"),
-            ])
             .map(|(k, v)| {
                 Element::builder(k, ns::VCARD4)
                     .append(Element::builder("text", ns::VCARD4).append(v))


### PR DESCRIPTION
Hey!

In order to match the recommended behavior described in https://xmpp.org/extensions/xep-0292.html#apps, I've set the `kind` of the workspace vCard to `application`.

Edit: Just noticed that you added an `org` kind already.