### PR TITLE
feat: Add Workspace XMPP account to everyone’s rosters

### DIFF
--- a/src/rest-api/src/features/init/init_server_config.rs
+++ b/src/rest-api/src/features/init/init_server_config.rs
@@ -77,6 +77,7 @@ impl CustomErrorCode for InitServerConfigError {
             Self::CouldNotInitServerConfig(err) => err.code(),
             Self::CouldNotRegisterOAuth2Client(err) => err.code(),
             Self::CouldNotCreateServiceAccount(err) => err.code(),
+            InitServerConfigError::CouldNotAddWorkspaceToTeam(err) => err.code(),
         }
     }
 }

--- a/src/rest-api/src/features/startup_actions/add_workspace_to_team.rs
+++ b/src/rest-api/src/features/startup_actions/add_workspace_to_team.rs
@@ -1,0 +1,48 @@
+// prose-pod-api
+//
+// Copyright: 2025, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use service::server_config::ServerConfigRepository;
+use tracing::{debug, info, instrument};
+
+use crate::{features::init::ServerConfigNotInitialized, AppState};
+
+/// NOTE: Users need to receive PEP events when the workspace vCard changes for
+///   Prose to update the UI automatically. For this, the Workspace needs to be
+///   in their rosters. By adding the Workspace to the team, it will automatically
+///   be added to everyone’s rosters.
+#[instrument(level = "trace", skip_all, err)]
+pub async fn add_workspace_to_team(
+    AppState {
+        db,
+        server_ctl,
+        app_config,
+        ..
+    }: &AppState,
+) -> Result<(), String> {
+    debug!("Adding the Workspace XMPP account to everyone’s rosters…");
+
+    let server_config = match ServerConfigRepository::get(db).await {
+        Ok(Some(server_config)) => server_config,
+        Ok(None) => {
+            info!("Not adding the Workspace XMPP account to everyone’s rosters: {ServerConfigNotInitialized}");
+            return Ok(());
+        }
+        Err(err) => {
+            return Err(format!(
+                "Could not add the Workspace XMPP account to everyone’s rosters: {err}"
+            ));
+        }
+    };
+
+    let workspace_jid = app_config.workspace_jid(&server_config.domain);
+
+    if let Err(err) = server_ctl.add_team_member(&workspace_jid).await {
+        return Err(format!(
+            "Could not add the Workspace XMPP account to everyone’s rosters: {err}"
+        ));
+    }
+
+    Ok(())
+}

--- a/src/rest-api/src/features/startup_actions/mod.rs
+++ b/src/rest-api/src/features/startup_actions/mod.rs
@@ -3,6 +3,7 @@
 // Copyright: 2023–2024, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
+mod add_workspace_to_team;
 mod create_service_accounts;
 mod init_server_config;
 mod register_oauth2_client;
@@ -15,6 +16,7 @@ use tracing::{instrument, trace};
 
 use crate::{error::DETAILED_ERROR_REPONSES, AppState};
 
+use self::add_workspace_to_team::*;
 use self::create_service_accounts::*;
 use self::init_server_config::*;
 use self::register_oauth2_client::*;
@@ -39,6 +41,7 @@ pub async fn run_startup_actions(app_state: &AppState) -> Result<(), String> {
     init_server_config(app_state).await?;
     register_oauth2_client(app_state).await?;
     create_service_accounts(app_state).await?;
+    add_workspace_to_team(app_state).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Users need to receive PEP events when the workspace vCard changes for Prose to update the UI automatically. For this, the Workspace needs to be in their rosters. By adding the Workspace to the team, it will automatically be added to everyone’s rosters.