### PR TITLE
Create release after tests pass #93

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ on:
       # We changed some packaged documentation:
       - "docs/openapi/**"
       - "src/*/static/**"
+
 jobs:
   create-github-release:
     if: startsWith(github.ref, 'refs/tags/') && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,26 @@ on:
     workflows: ["Lint & Test"]
     types:
       - completed
+  push:
+    tags:
+      - "v*.*.*"
+    # Do not run the workflow if the project hasn't changed.
+    # NOTE: It will run on every tag push, but only if the `paths` filter is satisfied on the chosen `branches`
+    #   (source: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).
+    paths:
+      # We changed the code:
+      - "src/*/src/**"
+      - "src/*/src/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      # We changed how the image is built:
+      - "Dockerfile"
+      - ".dockerignore"
+      # We changed how the workflow is ran:
+      - ".github/workflows/release.yaml"
+      # We changed some packaged documentation:
+      - "docs/openapi/**"
+      - "src/*/static/**"
 jobs:
   create-github-release:
     if: startsWith(github.ref, 'refs/tags/') && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ship-docker-image:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.ref == 'refs/heads/master' && github.event.workflow_run.conclusion == 'success'
     environment: build-ship
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,12 @@
 name: Release & Ship
 on:
-  push:
-    tags:
-      - "v*.*.*"
-    branches:
-      - master
-    # Do not run the workflow if the project hasn't changed.
-    # NOTE: It will run on every tag push, but only if the `paths` filter is satisfied on the chosen `branches`
-    #   (source: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).
-    paths:
-      # We changed the code:
-      - "src/*/src/**"
-      - "src/*/src/Cargo.toml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      # We changed how the image is built:
-      - "Dockerfile"
-      - ".dockerignore"
-      # We changed how the workflow is ran:
-      - ".github/workflows/release.yaml"
-      # We changed some packaged documentation:
-      - "docs/openapi/**"
-      - "src/*/static/**"
-
+  workflow_run:
+    workflows: ["Lint & Test"]
+    types:
+      - completed
 jobs:
   create-github-release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
@@ -44,6 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ship-docker-image:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: build-ship
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,6 @@
 name: Lint & Test
 on:
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - master
     # Do not run the workflow if the project hasn't changed.
@@ -17,7 +15,6 @@ on:
       - ".dockerignore"
       # We changed how the workflow is ran:
       - ".github/workflows/test.yaml"
-      - ".github/workflows/release.yaml"
       # We changed some packaged documentation:
       - "docs/openapi/**"
       - "src/*/static/**"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Lint & Test
 on:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - master
     # Do not run the workflow if the project hasn't changed.
@@ -15,6 +17,7 @@ on:
       - ".dockerignore"
       # We changed how the workflow is ran:
       - ".github/workflows/test.yaml"
+      - ".github/workflows/release.yaml"
       # We changed some packaged documentation:
       - "docs/openapi/**"
       - "src/*/static/**"


### PR DESCRIPTION
Hello @RemiBardon :wave: 

I'm opened this PR to resolve #93
In this PR, I modified the following

## `.github/workflows/release.yaml` 
I added a dependency on the test workflow using the `workflow_run` directive, as described in the [Stack Overflow article](https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions/64733705#64733705) you referenced in the issue.
I also added the condition `github.event.workflow_run.conclusion == 'success'` to the `create-github-release` and `ship-docker-image jobs`. According to this [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run), there are three activity types for `workflow_run`: **completed**, **requested**, and **in_progress**. If I understand correctly, the **completed** type only checks whether the workflow has finished, regardless of success or failure. 

In the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow) using a condition is suggested to execute the tasks based on the outcome of the triggering workflow, This ensures that the release jobs only run if the tests pass **successfully**.

From now on, the workflows will behave as

- **Lint & Test** runs on every push to master.
- **Release & Ship** runs when Lint & Test completes and also when a version tag is pushed.


I hope this meets your needs ! Let me know if any adjustments are required 🙏