### PR TITLE
Make sure no `@testing` or `@debug` is committed in feature files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,8 +84,8 @@ jobs:
 
       - name: Check unwanted tags
         run: |
-          if  find . -type f -name "*.feature" -exec grep -En '@(testing|debug)' {} +; then
-            echo "ERROR: Unwated tags found."
+          if grep -rEn --include="*.feature" '@(testing|debug)' . ; then
+            echo "ERROR: Unwanted tags found."
             exit 1
           else
             echo "No unwanted tags found in .feature files."

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,9 +76,24 @@ jobs:
       - name: Lint OpenAPI specification file
         run: docs/openapi/openapi-lint
 
+  check-no-unwanted-strings:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check unwanted tags
+        run: |
+          if  find . -type f -name "*.feature" -exec grep -En '@(testing|debug)' {} +; then
+            echo "ERROR: Unwated tags found."
+            exit 1
+          else
+            echo "No unwanted tags found in .feature files."
+          fi
+
   smoke-test:
     if: github.event.pull_request.draft == false
-    needs: [lint-rust, lint-openapi]
+    needs: [lint-rust, lint-openapi, check-no-unwanted-strings]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,12 +84,7 @@ jobs:
 
       - name: Check unwanted tags
         run: |
-          if grep -rEn --include="*.feature" '@(testing|debug)' . ; then
-            echo "ERROR: Unwanted tags found."
-            exit 1
-          else
-            echo "No unwanted tags found in .feature files."
-          fi
+          grep -rEn --include='*.feature' '@(testing|debug)' . && { echo 'ERROR: Unwanted tags found.'; exit 1; } || echo 'No unwanted tags found in .feature files.'
 
   smoke-test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check unwanted tags
+      - name: Ensure no debug tags are committed in feature files
         run: |
           grep -rEn --include='*.feature' '@(testing|debug)' . && { echo 'ERROR: Unwanted tags found.'; exit 1; } || echo 'No unwanted tags found in .feature files.'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,8 +83,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure no debug tags are committed in feature files
-        run: |
-          grep -rEn --include='*.feature' '@(testing|debug)' . && { echo 'ERROR: Unwanted tags found.'; exit 1; } || echo 'No unwanted tags found in .feature files.'
+        run: "! grep -rEn --include='*.feature' '@(testing|debug)' ."
 
   smoke-test:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Hello @RemiBardon :wave:
I've opened this PR to resolve #106 

As discussed in the issue, i have added a new job called `check-no-unwanted-strings` to the Lint & Test workflow.
This job searches through all `.feature` files in the repository and flags any lines containing the unwanted tags `@testing` or `@debug`.

As you suggested, this check uses `grep` commands, and **it will exit the workflow if any unwanted tags are found**.

I’ve also updated the `smoke-test` job dependencies to include this new job.

Let me know if any adjustments are needed! :smiley: