### PR TITLE
Onboarding docs and tests

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -26,5 +26,12 @@
     "**/.DS_Store",
     "**/redoc.standalone.js",
     "**/redoc.html"
-  ]
+  ],
+  "lsp": {
+    "cucumber": {
+      "settings": {
+        "glue": ["src/*/tests/features/*.rs"]
+      }
+    }
+  }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,7 @@ dependencies = [
 name = "prose-pod-api"
 version = "0.13.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "axum 0.8.3",
  "axum-extra",

--- a/docs/openapi/features/onboarding.yaml
+++ b/docs/openapi/features/onboarding.yaml
@@ -1,0 +1,29 @@
+paths:
+  get_onboarding_steps_statuses:
+    tags: [Init]
+    summary: Get onboarding steps statuses
+    description: |
+      Returns whether or not some actions have already been done to show onboarding steps in the
+      Dashboard if needed.
+    operationId: get_onboarding_steps_statuses
+    security:
+      - BearerAuth: []
+    responses:
+      "200":
+        description: Success
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/OnboardingStepsStatuses" }
+      "401": { $ref: "../shared.yaml#/components/responses/Unauthorized" }
+components:
+  schemas:
+    OnboardingStepsStatuses:
+      type: object
+      required:
+        - all_dns_checks_passed_once
+        - at_least_one_invitation_sent
+      properties:
+        all_dns_checks_passed_once:
+          type: boolean
+        at_least_one_invitation_sent:
+          type: boolean

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -20,6 +20,8 @@ paths:
   "/v1/init/first-account":
     put: { $ref: "features/init.yaml#/paths/init_first_account" }
     head: { $ref: "features/init.yaml#/paths/is_first_account_created" }
+  "/v1/onboarding-steps":
+    get: { $ref: "features/onboarding.yaml#/paths/get_onboarding_steps_statuses" }
 
   # ===== Auth =====
   "/v1/login":

--- a/features/network-checks/dns-record-checks.feature
+++ b/features/network-checks/dns-record-checks.feature
@@ -16,7 +16,7 @@ Feature: DNS record checks
         And prose.org's DNS zone has a AAAA record for xmpp.test.prose.org
         And prose.org's DNS zone has a SRV record for test.prose.org redirecting port 5222 to xmpp.test.prose.org.
         And prose.org's DNS zone has a SRV record for test.prose.org redirecting port 5269 to xmpp.test.prose.org.
-       When Valerian checks the DNS records configuration
+       When Valerian checks the DNS records configuration as "text/event-stream"
        Then the response is a SSE stream
         And one SSE event is "id:IPv4\nevent:dns-record-check-result\ndata:{\"description\":\"IPv4 record for xmpp.test.prose.org\",\"status\":\"CHECKING\"}"
         And one SSE event is "id:IPv6\nevent:dns-record-check-result\ndata:{\"description\":\"IPv6 record for xmpp.test.prose.org\",\"status\":\"CHECKING\"}"
@@ -33,7 +33,7 @@ Feature: DNS record checks
         And the XMPP server domain is test.prose.org
         And prose.org's DNS zone has a SRV record for test.prose.org redirecting port 5222 to cloud-provider.com.
         And prose.org's DNS zone has a SRV record for test.prose.org redirecting port 5269 to cloud-provider.com.
-       When Valerian checks the DNS records configuration
+       When Valerian checks the DNS records configuration as "text/event-stream"
        Then the response is a SSE stream
         And one SSE event is "id:SRV-c2s\nevent:dns-record-check-result\ndata:{\"description\":\"SRV record for client-to-server connections\",\"status\":\"CHECKING\"}"
         And one SSE event is "id:SRV-s2s\nevent:dns-record-check-result\ndata:{\"description\":\"SRV record for server-to-server connections\",\"status\":\"CHECKING\"}"

--- a/features/onboarding.feature
+++ b/features/onboarding.feature
@@ -1,0 +1,41 @@
+@onboarding
+Feature: Onboarding steps
+
+  Background:
+    Given the Prose Pod has been initialized for prose.org
+      And the Prose Pod API has started
+      And Valerian is an admin
+
+  Rule: One can know if DNS checks all passed once
+
+    Scenario: All checks pass
+      Given onboarding step "all_dns_checks_passed_once" is false
+        And the Prose Pod is publicly accessible via a hostname
+        And the XMPP server domain is test.prose.org
+        And prose.org’s DNS zone has a SRV record for test.prose.org redirecting port 5222 to cloud-provider.com.
+        And prose.org’s DNS zone has a SRV record for test.prose.org redirecting port 5269 to cloud-provider.com.
+       When Valerian checks the DNS records configuration
+        And Valerian queries onboarding steps statuses
+       Then onboarding step "all_dns_checks_passed_once" should be true
+
+    Scenario: All checks pass but one
+      Given onboarding step "all_dns_checks_passed_once" is false
+        And the Prose Pod is publicly accessible via a hostname
+        And the XMPP server domain is test.prose.org
+        And prose.org’s DNS zone has a SRV record for test.prose.org redirecting port 5222 to cloud-provider.com.
+       When Valerian checks the DNS records configuration
+        And Valerian queries onboarding steps statuses
+       Then onboarding step "all_dns_checks_passed_once" should be false
+
+  Rule: One can know if one invitation has already been sent
+
+    Scenario: No invitation sent yet
+      Given onboarding step "at_least_one_invitation_sent" is false
+       When Valerian queries onboarding steps statuses
+       Then onboarding step "at_least_one_invitation_sent" should be false
+
+    Scenario: After sending an invitation
+      Given onboarding step "at_least_one_invitation_sent" is false
+       When Valerian invites <remi@prose.org> as a MEMBER
+        And Valerian queries onboarding steps statuses
+       Then onboarding step "at_least_one_invitation_sent" should be true

--- a/src/rest-api/Cargo.toml
+++ b/src/rest-api/Cargo.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = [
     "macros",

--- a/src/rest-api/src/features/startup_actions/mod.rs
+++ b/src/rest-api/src/features/startup_actions/mod.rs
@@ -54,14 +54,15 @@ pub async fn run_startup_actions(app_state: AppState) -> Result<(), String> {
 
     // Some actions won’t prevent the API from running properly so let’s not
     // make startup longer because of it.
-    async fn run_remaining(app_state: AppState) -> Result<(), String> {
+    async fn run_remaining(app_state: &AppState) -> Result<(), String> {
         backfill_database(&app_state).await?;
         Ok(())
     }
     tokio::spawn(async move {
-        if let Err(err) = run_remaining(app_state).await {
+        if let Err(err) = run_remaining(&app_state).await {
             warn!("{}", crate::StartupError(err));
         }
+        app_state.lifecycle_manager.set_startup_actions_finished();
     });
 
     Ok(())

--- a/src/rest-api/tests/cucumber_parameters/boolean.rs
+++ b/src/rest-api/tests/cucumber_parameters/boolean.rs
@@ -1,0 +1,32 @@
+// prose-pod-api
+//
+// Copyright: 2025, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use std::{ops::Deref, str::FromStr};
+
+use cucumber::Parameter;
+
+#[derive(Debug, Parameter)]
+#[param(name = "bool", regex = "true|false")]
+pub struct Bool(bool);
+
+impl Deref for Bool {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromStr for Bool {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "true" => Self(true),
+            "false" => Self(false),
+            invalid => return Err(format!("Invalid `Bool`: {invalid}")),
+        })
+    }
+}

--- a/src/rest-api/tests/cucumber_parameters/mod.rs
+++ b/src/rest-api/tests/cucumber_parameters/mod.rs
@@ -7,6 +7,7 @@
 // See <https://cucumber-rs.github.io/cucumber/current/writing/capturing.html#custom-parameters>
 
 mod array;
+mod boolean;
 mod dns_record_type;
 mod domain_name;
 mod duration;
@@ -21,6 +22,7 @@ mod text;
 mod toggle_state;
 
 pub use array::*;
+pub use boolean::*;
 pub use dns_record_type::*;
 pub use domain_name::*;
 pub use duration::*;

--- a/src/rest-api/tests/features/mod.rs
+++ b/src/rest-api/tests/features/mod.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod invitations;
 pub mod members;
 pub mod network_checks;
+pub mod onboarding;
 pub mod pod_config;
 pub mod profiles;
 pub mod roles;

--- a/src/rest-api/tests/features/network_checks.rs
+++ b/src/rest-api/tests/features/network_checks.rs
@@ -5,8 +5,9 @@
 
 use super::prelude::*;
 
+api_call_fn!(check_dns_records, GET, "/v1/network/checks/dns");
 api_call_fn!(
-    check_dns_records,
+    check_dns_records_stream,
     GET,
     "/v1/network/checks/dns",
     accept: "text/event-stream"
@@ -16,6 +17,13 @@ api_call_fn!(
 async fn when_check_dns(world: &mut TestWorld, name: String) {
     let token = user_token!(world, name);
     let res = check_dns_records(world.api(), token).await;
+    world.result = Some(res.into());
+}
+
+#[when(expr = "{} checks the DNS records configuration as \"text\\/event-stream\"")]
+async fn when_check_dns_stream(world: &mut TestWorld, name: String) {
+    let token = user_token!(world, name);
+    let res = check_dns_records_stream(world.api(), token).await;
     world.result = Some(res.into());
 }
 

--- a/src/rest-api/tests/features/onboarding.rs
+++ b/src/rest-api/tests/features/onboarding.rs
@@ -1,0 +1,39 @@
+// prose-pod-api
+//
+// Copyright: 2025, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use cucumber::codegen::anyhow;
+use service::onboarding;
+
+use super::prelude::*;
+
+api_call_fn!(get_onboarding_steps_statuses, GET, "/v1/onboarding-steps");
+
+#[given(expr = "onboarding step {string} is {bool}")]
+async fn given_onboarding_step(
+    world: &mut TestWorld,
+    key: String,
+    status: parameters::Bool,
+) -> anyhow::Result<()> {
+    onboarding::KvStore::set_bool(world.db(), &key, *status).await?;
+    Ok(())
+}
+
+#[when(expr = "{} queries onboarding steps statuses")]
+async fn when_get_onboarding_step_statuses(world: &mut TestWorld, name: String) {
+    let token = user_token!(world, name);
+    let res = get_onboarding_steps_statuses(world.api(), token).await;
+    world.result = Some(res.into());
+}
+
+#[then(expr = "onboarding step {string} should be {bool}")]
+async fn then_onboarding_step(
+    world: &mut TestWorld,
+    key: String,
+    expected: parameters::Bool,
+) -> anyhow::Result<()> {
+    let status = onboarding::KvStore::get_bool(world.db(), &key).await?;
+    assert_eq!(status, Some(*expected));
+    Ok(())
+}

--- a/src/rest-api/tests/prelude/mocks/mock_network_checker.rs
+++ b/src/rest-api/tests/prelude/mocks/mock_network_checker.rs
@@ -103,6 +103,7 @@ impl NetworkCheckerImpl for MockNetworkChecker {
 }
 
 #[given(expr = "{domain_name}'s DNS zone has no {} record for {domain_name}")]
+#[given(expr = "{domain_name}’s DNS zone has no {} record for {domain_name}")]
 async fn given_no_record(
     _world: &mut TestWorld,
     _host: DomainName,
@@ -119,6 +120,7 @@ fn add_record(world: &mut TestWorld, dns_record: DnsRecord) {
 }
 
 #[given(expr = "{domain_name}'s DNS zone has a A record for {domain_name}")]
+#[given(expr = "{domain_name}’s DNS zone has a A record for {domain_name}")]
 async fn given_a_record(world: &mut TestWorld, _host: DomainName, record_hostname: DomainName) {
     add_record(
         world,
@@ -131,6 +133,7 @@ async fn given_a_record(world: &mut TestWorld, _host: DomainName, record_hostnam
 }
 
 #[given(expr = "{domain_name}'s DNS zone has a AAAA record for {domain_name}")]
+#[given(expr = "{domain_name}’s DNS zone has a AAAA record for {domain_name}")]
 async fn given_aaaa_record(world: &mut TestWorld, _host: DomainName, record_hostname: DomainName) {
     add_record(
         world,
@@ -144,6 +147,9 @@ async fn given_aaaa_record(world: &mut TestWorld, _host: DomainName, record_host
 
 #[given(
     expr = "{domain_name}'s DNS zone has a SRV record for {domain_name} redirecting port {int} to {domain_name}"
+)]
+#[given(
+    expr = "{domain_name}’s DNS zone has a SRV record for {domain_name} redirecting port {int} to {domain_name}"
 )]
 async fn given_srv_record(
     world: &mut TestWorld,


### PR DESCRIPTION
See #242.

This also fixes the fact that the API couldn’t update values inserted in the global key/value store… which means onboarding routes didn’t work properly.