### PR TITLE
chore(app-config)!: Make `skip_startup_actions` available in release builds

### DIFF
--- a/src/rest-api/src/features/startup_actions/mod.rs
+++ b/src/rest-api/src/features/startup_actions/mod.rs
@@ -39,9 +39,8 @@ macro_rules! run_step_macro {
     ($app_state:ident, $app_config:ident) => {
         macro_rules! run_step {
             ($step:ident) => {
-                #[cfg(debug_assertions)]
-                if ($app_config.debug_only.skip_startup_actions).contains(stringify!($step)) {
-                    tracing::warn!(
+                if ($app_config.debug.skip_startup_actions).contains(stringify!($step)) {
+                    warn!(
                         "Not running startup step '{}': Step marked to skip in the app configuration.",
                         stringify!($step),
                     );

--- a/src/service/src/features/app_config/mod.rs
+++ b/src/service/src/features/app_config/mod.rs
@@ -7,10 +7,8 @@
 
 pub mod defaults;
 
-#[cfg(debug_assertions)]
-use std::collections::HashSet;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     net::IpAddr,
     path::{Path, PathBuf},
     str::FromStr as _,
@@ -601,6 +599,10 @@ pub struct DebugConfig {
     pub detailed_error_responses: bool,
     #[serde(default = "defaults::always_false")]
     pub c2s_unencrypted: bool,
+    // NOTE: Needs to be available in release builds so we can run the CI in
+    //   `prose-pod-system` without having to start live notifiers.
+    #[serde(default)]
+    pub skip_startup_actions: HashSet<String>,
 }
 
 impl Default for DebugConfig {
@@ -609,6 +611,7 @@ impl Default for DebugConfig {
             log_config_at_startup: defaults::true_in_debug(),
             detailed_error_responses: defaults::true_in_debug(),
             c2s_unencrypted: defaults::always_false(),
+            skip_startup_actions: Default::default(),
         }
     }
 }
@@ -622,8 +625,6 @@ pub struct DebugOnlyConfig {
     pub insecure_password_on_auto_accept_invitation: bool,
     #[serde(default)]
     pub dependency_modes: DependencyModesConfig,
-    #[serde(default)]
-    pub skip_startup_actions: HashSet<String>,
 }
 
 #[cfg(debug_assertions)]

--- a/tests/integration/prose-tokens-expired.toml
+++ b/tests/integration/prose-tokens-expired.toml
@@ -18,5 +18,5 @@ smtp_encrypt = false
 # Expire tokens immediately, allowing successful log in but not subsequent requests.
 token_ttl = "PT0S"
 
-[debug_only]
+[debug_use_at_your_own_risk]
 skip_startup_actions = ["migrate_workspace_vcard"]


### PR DESCRIPTION
Renames `debug_only.skip_startup_actions` to `debug_use_at_your_own_risk.skip_startup_actions`.

NOTE: Needs to be available in release builds so we can run the CI in `prose-pod-system` without having to start live notifiers.
