### PR TITLE
feat: Load XMPP users at startup

### DIFF
--- a/local-run/scripts/constants.sh
+++ b/local-run/scripts/constants.sh
@@ -2,7 +2,7 @@
 #   It avoids resetting a variable when sourcing this file after the variable was overriden.
 
 : ${PROSE_POD_API_IMAGE_TAG:=0.16.3}
-: ${PROSE_POD_SERVER_IMAGE_TAG:=0.3.21}
+: ${PROSE_POD_SERVER_IMAGE_TAG:=0.3.22}
 : ${PROSE_POD_DASHBOARD_IMAGE_TAG:=0.1.0}
 LOCAL_RUN_DIR="${REPOSITORY_ROOT:?}"/local-run
 : ${COMPOSE_FILE:="${LOCAL_RUN_DIR:?}"/compose.yaml}

--- a/src/rest-api/src/features/startup_actions/backfill_database.rs
+++ b/src/rest-api/src/features/startup_actions/backfill_database.rs
@@ -3,10 +3,31 @@
 // Copyright: 2025, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
+use std::sync::Arc;
+
+use service::{
+    invitations::{InvitationContact, InvitationRepository},
+    members::{MemberRole, UnauthenticatedMemberService, UserCreateError},
+    sea_orm::TransactionTrait as _,
+};
+use tracing::{info, warn};
+
 use crate::AppState;
 
 #[tracing::instrument(level = "trace", skip_all, err)]
-pub async fn backfill_database(
+pub async fn backfill_database(app_state: &AppState) -> Result<(), String> {
+    tracing::debug!("Backfilling database…");
+
+    // Backfill onboarding steps status.
+    backfill_onboarding_steps(app_state).await?;
+
+    // Backfill users manually created in the XMPP server.
+    backfill_xmpp_users(app_state).await?;
+
+    Ok(())
+}
+
+pub async fn backfill_onboarding_steps(
     AppState {
         db,
         app_config,
@@ -15,10 +36,100 @@ pub async fn backfill_database(
         ..
     }: &AppState,
 ) -> Result<(), String> {
-    tracing::debug!("Backfilling database…");
-
     let ref app_config = app_config.read().unwrap().clone();
     service::onboarding::backfill(db, app_config, network_checker, uuid_gen).await;
+    Ok(())
+}
+
+pub async fn backfill_xmpp_users(
+    AppState {
+        db,
+        server_ctl,
+        auth_service,
+        xmpp_service,
+        ..
+    }: &AppState,
+) -> Result<(), String> {
+    // Load users from the XMPP server (in case of a manual migration).
+    let users = (server_ctl.list_users().await)
+        .map_err(|err| format!("Could not list XMPP accounts: {err}"))?;
+
+    let member_service = UnauthenticatedMemberService::new(
+        Arc::new(server_ctl.clone()),
+        Arc::new(auth_service.clone()),
+        Arc::new(xmpp_service.clone()),
+    );
+
+    for user in users.iter() {
+        // Map XMPP server roles to Prose roles.
+        let Some(role) = Option::<MemberRole>::from(&user.role) else {
+            continue;
+        };
+
+        // Create member in database if it doesn’t exist already.
+        match member_service.exists(db, &user.jid).await {
+            Ok(false) => {
+                let txn = (db.begin().await)
+                    .map_err(|err| format!("Could not start transaction: {err}"))?;
+
+                // Try to find email address in an invitation,
+                // and delete the invitation if one exists.
+                let email_address = match InvitationRepository::get_by_jid(&txn, &user.jid).await {
+                    Ok(Some(invitation)) => {
+                        // Read the email address.
+                        let email_address = match invitation.contact() {
+                            InvitationContact::Email { email_address } => Some(email_address),
+                        };
+
+                        // Delete the invitation.
+                        if let Err(err) =
+                            InvitationRepository::delete_by_id(&txn, invitation.id).await
+                        {
+                            warn!(
+                                "Could not delete invitation for {jid}: {err}",
+                                jid = user.jid
+                            );
+                        }
+
+                        email_address
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        warn!("Could not find invitation for {jid}: {err}", jid = user.jid);
+                        None
+                    }
+                };
+                // TODO: Try to read the email address from the user’s vCard if `None`?
+
+                // Create the user in the Pod API database.
+                // NOTE: Prosody doesn’t store the “joined at” timestamp.
+                //   We can’t pass it down to `MemberRepository::create`.
+                member_service
+                    .create_user_local(&txn, &user.jid, &Some(role), email_address)
+                    .await
+                    .map_err(|err| format!("Could not create user {jid}: {err}", jid = user.jid))?;
+
+                (txn.commit().await)
+                    .map_err(|err| format!("Could not create user {jid}: {err}", jid = user.jid))?;
+
+                info!(
+                    "Created user {jid} (found in XMPP server, was missing in API database).",
+                    jid = user.jid,
+                );
+
+                // Add the user to everyone's roster (if needed).
+                server_ctl.add_team_member(&user.jid).await.map_err(|err| {
+                    UserCreateError::XmppServerCannotAddTeamMember(err).to_string()
+                })?;
+            }
+            Ok(true) => {
+                // User already exists, do nothing.
+            }
+            Err(_) => {
+                // Database in faulty state, can’t create members anyway.
+            }
+        }
+    }
 
     Ok(())
 }

--- a/src/rest-api/src/features/startup_actions/mod.rs
+++ b/src/rest-api/src/features/startup_actions/mod.rs
@@ -88,8 +88,10 @@ pub async fn run_startup_actions(app_state: AppState) -> Result<(), String> {
 
         run_step_macro!(app_state, app_config);
 
-        run_step!(update_rosters);
         run_step!(backfill_database);
+        // NOTE: `update_rosters` should run after `backfill_database`
+        //   as the latter can add team members.
+        run_step!(update_rosters);
 
         Ok(())
     }

--- a/src/rest-api/tests/prelude/mocks/mock_server_ctl.rs
+++ b/src/rest-api/tests/prelude/mocks/mock_server_ctl.rs
@@ -10,7 +10,10 @@ use service::{
     members::MemberRole,
     prosody::{prosody_bootstrap_config, AsProsody as _, ProsodyConfig},
     prosody_config_from_db,
-    xmpp::{server_ctl::Error, BareJid},
+    xmpp::{
+        server_ctl::{self, Error},
+        BareJid,
+    },
     AppConfig, ProsodyConfigSection, ServerConfig,
 };
 
@@ -92,6 +95,10 @@ impl ServerCtlImpl for MockServerCtl {
         Ok(())
     }
 
+    async fn list_users(&self) -> Result<Vec<server_ctl::User>, Error> {
+        // Do nothing, this is used only at startup.
+        Ok(Vec::new())
+    }
     async fn add_user(&self, jid: &BareJid, password: &SecretString) -> Result<(), Error> {
         self.check_online()?;
 

--- a/src/service/src/features/members/member_repository.rs
+++ b/src/service/src/features/members/member_repository.rs
@@ -55,6 +55,18 @@ impl MemberRepository {
     }
 
     #[instrument(
+        name = "db::member::exists", level = "trace",
+        skip_all, fields(jid = jid.to_string()),
+        err
+    )]
+    pub async fn exists(db: &impl ConnectionTrait, jid: &BareJid) -> Result<bool, DbErr> {
+        match Entity::find_by_jid(&jid.to_owned().into()).count(db).await {
+            Ok(count) => Ok(count > 0),
+            Err(err) => Err(err),
+        }
+    }
+
+    #[instrument(
         name = "db::member::get", level = "trace",
         skip_all, fields(jid = jid.to_string()),
         err

--- a/src/service/src/features/prosody/mod.rs
+++ b/src/service/src/features/prosody/mod.rs
@@ -3,7 +3,7 @@
 // Copyright: 2024, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-mod prosody_admin_rest;
+pub mod prosody_admin_rest;
 mod prosody_bootstrap_config;
 pub mod prosody_config;
 mod prosody_config_from_db;
@@ -29,6 +29,7 @@ pub trait AsProsody {
 
 impl AsProsody for MemberRole {
     /// NOTE: Built-in roles are defined in `mod_authz_internal.lua` (under section `-- Default roles`).
+    #[inline]
     fn as_prosody(&self) -> String {
         match self {
             MemberRole::Member => "prosody:member",


### PR DESCRIPTION
Load XMPP users at startup. If ones are not in the Pod API database, create them. If there are open invitations for them, read the email address then delete the invitation.

This improves the migration UX.