### PR TITLE
fix(prosody): Do not set `http_interfaces` to `{ "*" }`

### DIFF
--- a/src/service/src/features/prosody/prosody_bootstrap_config.rs
+++ b/src/service/src/features/prosody/prosody_bootstrap_config.rs
@@ -29,7 +29,6 @@ pub fn global_settings() -> prosody_config::ProsodySettings {
                 .into_iter()
                 .collect(),
         ),
-        http_interfaces: Some(vec![Interface::AllIPv4].into_iter().collect()),
         https_ports: Some(Default::default()),
         https_interfaces: Some(Default::default()),
         plugin_paths: Some(

--- a/src/service/tests/prosody/snapshots/behavior__prosody__default_config.snap
+++ b/src/service/tests/prosody/snapshots/behavior__prosody__default_config.snap
@@ -23,7 +23,6 @@ log = {
 interfaces = { "*" }
 c2s_ports = { 5222 }
 http_ports = { 5280 }
-http_interfaces = { "*" }
 https_ports = {}
 https_interfaces = {}
 

--- a/src/service/tests/prosody/snapshots/behavior__prosody__minimal_config.snap
+++ b/src/service/tests/prosody/snapshots/behavior__prosody__minimal_config.snap
@@ -23,7 +23,6 @@ log = {
 interfaces = { "*" }
 c2s_ports = { 5222 }
 http_ports = { 5280 }
-http_interfaces = { "*" }
 https_ports = {}
 https_interfaces = {}
 


### PR DESCRIPTION
Fixes #287.