### PR TITLE
fix: Fix database locks by opening two connection pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "serde_json",
  "toml",
  "uncased",
  "version_check",

--- a/src/rest-api/src/features/auth/extractors/is_admin.rs
+++ b/src/rest-api/src/features/auth/extractors/is_admin.rs
@@ -22,7 +22,7 @@ impl FromRequestParts<AppState> for IsAdmin {
         let user_info = UserInfo::from_request_parts(parts, state).await?;
         let jid = user_info.jid;
 
-        if MemberRepository::is_admin(&state.db, &jid).await? {
+        if MemberRepository::is_admin(&state.db.read, &jid).await? {
             Ok(Self)
         } else {
             Err(Error::from(error::Forbidden(format!(

--- a/src/rest-api/src/features/auth/extractors/user_info.rs
+++ b/src/rest-api/src/features/auth/extractors/user_info.rs
@@ -42,7 +42,10 @@ impl FromRequestParts<AppState> for service::auth::UserInfo {
 
         // Get user info from auth token.
         let token = AuthToken::from_request_parts(parts, state).await?;
-        let res = (state.auth_service.get_user_info(token, &state.db).await)
+        let res = state
+            .auth_service
+            .get_user_info(token, &state.db.read)
+            .await
             .context("Could not get user info from token")
             .map_err(Error::from);
 

--- a/src/rest-api/src/features/auth/routes.rs
+++ b/src/rest-api/src/features/auth/routes.rs
@@ -59,7 +59,7 @@ pub async fn set_member_role_route(
     Path(jid): Path<BareJid>,
     Json(role): Json<MemberRole>,
 ) -> Result<Json<MemberRole>, Error> {
-    match auth_controller::set_member_role(db, member_service, user_info, jid, role).await? {
+    match auth_controller::set_member_role(&db.write, member_service, user_info, jid, role).await? {
         () => Ok(Json(role)),
     }
 }
@@ -76,8 +76,14 @@ pub async fn request_password_reset_route(
     ref caller: UserInfo,
     Path(ref jid): Path<BareJid>,
 ) -> Result<StatusCode, Error> {
-    auth_controller::request_password_reset(db, notification_service, app_config, caller, jid)
-        .await?;
+    auth_controller::request_password_reset(
+        &db.write,
+        notification_service,
+        app_config,
+        caller,
+        jid,
+    )
+    .await?;
     Ok(StatusCode::ACCEPTED)
 }
 
@@ -96,7 +102,7 @@ pub async fn reset_password_route(
     Path(ref token): Path<PasswordResetToken>,
     Json(ResetPasswordRequest { password }): Json<ResetPasswordRequest>,
 ) -> Result<(), Error> {
-    auth_controller::reset_password(db, server_ctl, token, &password).await?;
+    auth_controller::reset_password(&db.write, server_ctl, token, &password).await?;
     Ok(())
 }
 

--- a/src/rest-api/src/features/init/extractors/init_service.rs
+++ b/src/rest-api/src/features/init/extractors/init_service.rs
@@ -13,7 +13,7 @@ impl FromRequestParts<AppState> for service::init::InitService {
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         Ok(Self {
-            db: Arc::new(state.db.clone()),
+            db: state.db.clone(),
         })
     }
 }

--- a/src/rest-api/src/features/init/routes.rs
+++ b/src/rest-api/src/features/init/routes.rs
@@ -55,7 +55,7 @@ pub async fn init_first_account_route(
 pub async fn is_first_account_created_route(
     State(AppState { db, .. }): State<AppState>,
 ) -> StatusCode {
-    if MemberRepository::count(&db).await.unwrap_or_default() == 0 {
+    if MemberRepository::count(&db.read).await.unwrap_or_default() == 0 {
         StatusCode::NO_CONTENT
     } else {
         StatusCode::OK

--- a/src/rest-api/src/features/invitations/routes.rs
+++ b/src/rest-api/src/features/invitations/routes.rs
@@ -95,7 +95,7 @@ pub async fn invite_member_route(
 ) -> InviteMemberResponse {
     let res = invitation_controller::invite_member(
         #[cfg(debug_assertions)]
-        db,
+        &db.write,
         app_config,
         app_config.server_domain(),
         notification_service,

--- a/src/rest-api/src/features/licensing/mod.rs
+++ b/src/rest-api/src/features/licensing/mod.rs
@@ -57,7 +57,7 @@ async fn get_licensing_status(
         ..
     }): State<AppState>,
 ) -> Result<Json<GetLicensingStatusResponse>, Error> {
-    match licensing_controller::get_licensing_status(license_service, db).await {
+    match licensing_controller::get_licensing_status(license_service, &db.read).await {
         Ok(status) => Ok(Json(status)),
         Err(err) => Err(Error::from(err)),
     }

--- a/src/rest-api/src/features/members/extractors/member_service.rs
+++ b/src/rest-api/src/features/members/extractors/member_service.rs
@@ -24,7 +24,7 @@ impl FromRequestParts<AppState> for service::members::MemberService {
         };
 
         Ok(Self::new(
-            Arc::new(state.db.clone()),
+            state.db.clone(),
             Arc::new(state.server_ctl.clone()),
             Arc::new(xmpp_service),
             ConcurrentTaskRunner::default(),

--- a/src/rest-api/src/features/members/routes.rs
+++ b/src/rest-api/src/features/members/routes.rs
@@ -52,7 +52,7 @@ pub async fn delete_member_route(
     Path(jid): Path<BareJid>,
     member_service: MemberService,
 ) -> Result<StatusCode, Error> {
-    member_controller::delete_member(&db, &jid, &member_service).await?;
+    member_controller::delete_member(&db.write, &jid, &member_service).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -77,7 +77,7 @@ pub async fn get_members_route(
 pub async fn head_members(
     State(AppState { ref db, .. }): State<AppState>,
 ) -> Result<Paginated<Member>, Error> {
-    match member_controller::head_members(db).await? {
+    match member_controller::head_members(&db.read).await? {
         members => Ok(members.map(Into::into).into()),
     }
 }

--- a/src/rest-api/src/features/network_checks/check_all.rs
+++ b/src/rest-api/src/features/network_checks/check_all.rs
@@ -56,8 +56,10 @@ async fn check_network_configuration_route_(
         let pod_network_config = pod_network_config.clone();
         let network_checker = network_checker.clone();
         tasks.push_back(tokio::spawn(
-            async move { check_dns_records_route__(pod_network_config, network_checker, &db).await }
-                .in_current_span(),
+            async move {
+                check_dns_records_route__(pod_network_config, network_checker, &db.read).await
+            }
+            .in_current_span(),
         ));
     }
     {
@@ -145,7 +147,7 @@ async fn check_network_configuration_stream_route_(
                         move || {
                             tokio::spawn(async move {
                                 trace!("Setting `all_dns_checks_passed_once` to true…");
-                                (onboarding::all_dns_checks_passed_once::set(&db, true).await)
+                                (onboarding::all_dns_checks_passed_once::set(&db.write, true).await)
                                     .inspect_err(|err| {
                                         warn!("Could not set `all_dns_checks_passed_once` to true: {err}")
                                     })

--- a/src/rest-api/src/features/network_checks/check_dns_records.rs
+++ b/src/rest-api/src/features/network_checks/check_dns_records.rs
@@ -63,7 +63,7 @@ async fn check_dns_records_route_(
     pod_network_config: PodNetworkConfig,
     network_checker: NetworkChecker,
 ) -> Result<Json<Vec<NetworkCheckResult>>, Error> {
-    let res = check_dns_records_route__(pod_network_config, network_checker, &db).await;
+    let res = check_dns_records_route__(pod_network_config, network_checker, &db.read).await;
     Ok(Json(res))
 }
 
@@ -85,7 +85,7 @@ async fn check_dns_records_stream_route_(
             tokio::spawn(
                 async move {
                     trace!("Setting `all_dns_checks_passed_once` to true…");
-                    (onboarding::all_dns_checks_passed_once::set(&db, true).await)
+                    (onboarding::all_dns_checks_passed_once::set(&db.write, true).await)
                         .inspect_err(|err| {
                             warn!("Could not set `all_dns_checks_passed_once` to true: {err}")
                         })

--- a/src/rest-api/src/features/onboarding.rs
+++ b/src/rest-api/src/features/onboarding.rs
@@ -26,5 +26,5 @@ pub(super) fn router(app_state: AppState) -> axum::Router {
 async fn onboarding_steps_route(
     State(AppState { ref db, .. }): State<AppState>,
 ) -> Json<OnboardingStepsStatuses> {
-    Json(onboarding::get_steps_statuses(db).await)
+    Json(onboarding::get_steps_statuses(&db.read).await)
 }

--- a/src/rest-api/src/features/pod_config/extractors/pod_network_config.rs
+++ b/src/rest-api/src/features/pod_config/extractors/pod_network_config.rs
@@ -23,7 +23,8 @@ impl FromRequestParts<AppState> for service::network_checks::PodNetworkConfig {
         let is_admin = IsAdmin::from_request_parts(parts, state).await?;
 
         let server_config =
-            server_config_controller::get_server_config_private(db, app_config, &is_admin).await?;
+            server_config_controller::get_server_config_private(&db.read, app_config, &is_admin)
+                .await?;
 
         Ok(Self::new(app_config, server_config.federation_enabled))
     }

--- a/src/rest-api/src/features/profile.rs
+++ b/src/rest-api/src/features/profile.rs
@@ -78,7 +78,7 @@ mod routes {
             Err(error::Forbidden("You cannot do that.".to_string()))?
         }
 
-        MemberRepository::set_email_address(db, &jid, Some(email_address)).await?;
+        MemberRepository::set_email_address(&db.write, &jid, Some(email_address)).await?;
 
         Ok(NoContent)
     }
@@ -92,7 +92,7 @@ mod routes {
             Err(error::Forbidden("You cannot do that.".to_string()))?
         }
 
-        let email_address = MemberRepository::get_email_address(db, &jid).await?;
+        let email_address = MemberRepository::get_email_address(&db.read, &jid).await?;
 
         Ok(Json(email_address))
     }

--- a/src/rest-api/src/features/reports.rs
+++ b/src/rest-api/src/features/reports.rs
@@ -50,7 +50,7 @@ async fn get_cloud_api_report(
 ) -> Result<Json<GetCloudApiReportResponse>, Error> {
     let timestamp = Timestamp::now_utc();
     let versions = pod_version_controller::get_pod_version(pod_version_service).await?;
-    let licensing = licensing_controller::get_licensing_status(license_service, db).await?;
+    let licensing = licensing_controller::get_licensing_status(license_service, &db.read).await?;
     let workspace = workspace_controller::get_workspace(workspace_service).await?;
     let server = server_config_controller::get_server_config_public(app_config);
     let dashboard = app_config.dashboard.clone();

--- a/src/rest-api/src/features/server_config/extractors/server_config_manager.rs
+++ b/src/rest-api/src/features/server_config/extractors/server_config_manager.rs
@@ -8,7 +8,7 @@ use crate::extractors::prelude::*;
 impl FromRef<AppState> for service::server_config::ServerConfigManager {
     fn from_ref(state: &AppState) -> Self {
         Self::new(
-            Arc::new(state.db.clone()),
+            state.db.clone(),
             state.app_config.clone(),
             Arc::new(state.server_ctl.clone()),
         )

--- a/src/rest-api/src/features/server_config/routes.rs
+++ b/src/rest-api/src/features/server_config/routes.rs
@@ -31,7 +31,7 @@ pub mod server_config {
         State(ref app_config): State<Arc<AppConfig>>,
         is_admin: Option<IsAdmin>,
     ) -> Result<Either<Json<ServerConfig>, Json<PublicServerConfig>>, Error> {
-        match server_config_controller::get_server_config(db, app_config, is_admin).await? {
+        match server_config_controller::get_server_config(&db.read, app_config, is_admin).await? {
             service::util::either::Either::E1(config) => Ok(Either::E1(Json(config))),
             service::util::either::Either::E2(config) => Ok(Either::E2(Json(config))),
         }
@@ -59,7 +59,7 @@ macro_rules! server_config_routes {
                 State(AppState { ref db, .. }): State<AppState>,
                 State(ref app_config): State<Arc<AppConfig>>,
             ) -> Result<Json<$var_type>, Error> {
-                match server_config_controller::$var::get(db, app_config).await? {
+                match server_config_controller::$var::get(&db.read, app_config).await? {
                     $var => Ok(Json($var)),
                 }
             }
@@ -215,7 +215,7 @@ pub mod prosody_overrides {
         State(AppState { ref db, .. }): State<AppState>,
         State(ref app_config): State<Arc<AppConfig>>,
     ) -> Result<Either<Json<ProsodySettings>, NoContent>, Error> {
-        match server_config_controller::prosody_overrides::get(db, app_config).await? {
+        match server_config_controller::prosody_overrides::get(&db.read, app_config).await? {
             Some(overrides) => Ok(Either::E1(Json(overrides))),
             None => Ok(Either::E2(NoContent)),
         }
@@ -224,7 +224,7 @@ pub mod prosody_overrides {
     pub async fn delete(
         State(AppState { ref db, .. }): State<AppState>,
     ) -> Result<NoContent, Error> {
-        match server_config_controller::prosody_overrides::delete(db).await? {
+        match server_config_controller::prosody_overrides::delete(&db.write).await? {
             _ => Ok(NoContent),
         }
     }
@@ -249,7 +249,7 @@ pub mod prosody_overrides_raw {
         State(AppState { ref db, .. }): State<AppState>,
         State(ref app_config): State<Arc<AppConfig>>,
     ) -> Result<Either<Lua, NoContent>, Error> {
-        match server_config_controller::prosody_overrides_raw::get(db, app_config).await? {
+        match server_config_controller::prosody_overrides_raw::get(&db.read, app_config).await? {
             Some(overrides) => Ok(Either::E1(Lua::from(overrides))),
             None => Ok(Either::E2(NoContent)),
         }
@@ -258,7 +258,7 @@ pub mod prosody_overrides_raw {
     pub async fn delete(
         State(AppState { ref db, .. }): State<AppState>,
     ) -> Result<NoContent, Error> {
-        match server_config_controller::prosody_overrides_raw::delete(db).await? {
+        match server_config_controller::prosody_overrides_raw::delete(&db.write).await? {
             _ => Ok(NoContent),
         }
     }

--- a/src/rest-api/src/features/startup_actions/backfill_database.rs
+++ b/src/rest-api/src/features/startup_actions/backfill_database.rs
@@ -67,9 +67,9 @@ pub async fn backfill_xmpp_users(
         };
 
         // Create member in database if it doesn’t exist already.
-        match member_service.exists(db, &user.jid).await {
+        match member_service.exists(&db.read, &user.jid).await {
             Ok(false) => {
-                let txn = (db.begin().await)
+                let txn = (db.write.begin().await)
                     .map_err(|err| format!("Could not start transaction: {err}"))?;
 
                 // Try to find email address in an invitation,

--- a/src/rest-api/src/features/startup_actions/db_configure.rs
+++ b/src/rest-api/src/features/startup_actions/db_configure.rs
@@ -1,0 +1,22 @@
+// prose-pod-api
+//
+// Copyright: 2025, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use service::sea_orm::ConnectionTrait as _;
+use tracing::{debug, instrument};
+
+use crate::AppState;
+
+#[instrument(level = "trace", skip_all, err)]
+pub async fn db_configure(AppState { db, .. }: &AppState) -> Result<(), String> {
+    debug!("Configuring the database…");
+
+    // Allow simultaneous reads with one writer.
+    db.write
+        .execute_unprepared("PRAGMA journal_mode=WAL;")
+        .await
+        .map_err(|err| format!("Could not set `journal_mode=WAL`: {err}"))?;
+
+    Ok(())
+}

--- a/src/rest-api/src/features/startup_actions/db_run_migrations.rs
+++ b/src/rest-api/src/features/startup_actions/db_run_migrations.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 use crate::AppState;
 
 #[instrument(level = "trace", skip_all, err)]
-pub async fn run_migrations(AppState { db, .. }: &AppState) -> Result<(), String> {
-    let _ = service::Migrator::up(db, None).await;
+pub async fn db_run_migrations(AppState { db, .. }: &AppState) -> Result<(), String> {
+    let _ = service::Migrator::up(&db.write, None).await;
     Ok(())
 }

--- a/src/rest-api/src/features/startup_actions/init_server_config.rs
+++ b/src/rest-api/src/features/startup_actions/init_server_config.rs
@@ -13,7 +13,7 @@ use crate::AppState;
 pub async fn init_server_config(app_state @ AppState { db, .. }: &AppState) -> Result<(), String> {
     debug!("Initializing the XMPP server configuration…");
 
-    let server_config = (server_config::get(db).await)
+    let server_config = (server_config::get(&db.read).await)
         .map_err(|err| format!("Could not initialize the XMPP server configuration: {err}"))?;
 
     // Apply the server configuration stored in the database

--- a/src/rest-api/src/features/startup_actions/mod.rs
+++ b/src/rest-api/src/features/startup_actions/mod.rs
@@ -6,11 +6,12 @@
 mod add_workspace_to_team;
 mod backfill_database;
 mod create_service_accounts;
+mod db_configure;
+mod db_run_migrations;
 mod init_server_config;
 mod migrate_workspace_vcard;
 mod register_oauth2_client;
 mod rotate_api_xmpp_password;
-mod run_migrations;
 mod start_cron_tasks;
 mod test_services_reachability;
 mod update_rosters;
@@ -24,11 +25,12 @@ use crate::{error::DETAILED_ERROR_REPONSES, AppState};
 use self::add_workspace_to_team::*;
 use self::backfill_database::*;
 use self::create_service_accounts::*;
+use self::db_configure::*;
+use self::db_run_migrations::*;
 use self::init_server_config::*;
 use self::migrate_workspace_vcard::*;
 use self::register_oauth2_client::*;
 use self::rotate_api_xmpp_password::*;
-use self::run_migrations::*;
 use self::start_cron_tasks::*;
 use self::test_services_reachability::*;
 use self::update_rosters::*;
@@ -68,7 +70,8 @@ pub async fn run_startup_actions(app_state: AppState) -> Result<(), String> {
     {
         run_step_macro!(app_state, app_config);
 
-        run_step!(run_migrations);
+        run_step!(db_configure);
+        run_step!(db_run_migrations);
         run_step!(test_services_reachability);
         run_step!(wait_for_server);
         run_step!(rotate_api_xmpp_password);

--- a/src/rest-api/src/features/startup_actions/validate_app_config_changes.rs
+++ b/src/rest-api/src/features/startup_actions/validate_app_config_changes.rs
@@ -20,7 +20,7 @@ pub async fn validate_app_config_changes(app_state: &AppState) -> Result<(), Str
 async fn ensure_server_domain_not_changed(
     AppState { db, app_config, .. }: &AppState,
 ) -> Result<(), String> {
-    let (_, members) = (MemberRepository::get_page(db, 1, 1, None).await)
+    let (_, members) = (MemberRepository::get_page(&db.read, 1, 1, None).await)
         .map_err(|err| format!("Could not ensure the server domain hasn’t been modified: {err}"))?;
 
     let Some(member) = members.first() else {

--- a/src/rest-api/src/lib.rs
+++ b/src/rest-api/src/lib.rs
@@ -20,10 +20,10 @@ use service::{
     dependencies::Uuid,
     factory_reset::FactoryResetService,
     licensing::LicenseService,
+    models::DatabaseRwConnectionPools,
     network_checks::NetworkChecker,
     notifications::{notifier::email::EmailNotification, Notifier},
     pod_version::PodVersionService,
-    sea_orm::DatabaseConnection,
     secrets::SecretsStore,
     xmpp::{ServerCtl, XmppServiceInner},
     AppConfig,
@@ -38,7 +38,7 @@ pub trait AxumState: Clone + Send + Sync + 'static {}
 #[derive(Debug, Clone)]
 pub struct AppState {
     base: MinimalAppState,
-    db: DatabaseConnection,
+    db: DatabaseRwConnectionPools,
     app_config: Arc<AppConfig>,
     server_ctl: ServerCtl,
     xmpp_service: XmppServiceInner,
@@ -54,7 +54,7 @@ pub struct AppState {
 impl AppState {
     pub fn new(
         base: MinimalAppState,
-        db: DatabaseConnection,
+        db: DatabaseRwConnectionPools,
         app_config: Arc<AppConfig>,
         server_ctl: ServerCtl,
         xmpp_service: XmppServiceInner,

--- a/src/rest-api/src/main.rs
+++ b/src/rest-api/src/main.rs
@@ -180,9 +180,12 @@ async fn startup(app_config: AppConfig, minimal_app_state: MinimalAppState) -> R
 
 #[instrument(level = "trace", skip_all)]
 async fn init_dependencies(app_config: AppConfig, base: MinimalAppState) -> AppState {
-    let db = db_conn(&app_config.api.databases.main)
-        .await
-        .expect("Could not connect to the database.");
+    let db = db_conn(
+        &app_config.api.databases.main_read,
+        &app_config.api.databases.main_write,
+    )
+    .await
+    .expect("Could not connect to the database.");
 
     let license_service_impl = match LiveLicenseService::from_config(&app_config) {
         Ok(service) => service,

--- a/src/rest-api/tests/features/dns_setup.rs
+++ b/src/rest-api/tests/features/dns_setup.rs
@@ -16,7 +16,7 @@ use crate::{api_call_fn, cucumber_parameters::*, user_token, TestWorld};
 
 #[given(expr = "federation is {toggle}")]
 async fn given_federation(world: &mut TestWorld, enabled: ToggleState) -> Result<(), Error> {
-    server_config::federation_enabled::set(world.db(), enabled.as_bool()).await?;
+    server_config::federation_enabled::set(&world.db.write, enabled.as_bool()).await?;
     Ok(())
 }
 

--- a/src/rest-api/tests/features/onboarding.rs
+++ b/src/rest-api/tests/features/onboarding.rs
@@ -16,7 +16,7 @@ async fn given_onboarding_step(
     key: String,
     status: parameters::Bool,
 ) -> anyhow::Result<()> {
-    onboarding::set_bool(world.db(), &key, *status).await?;
+    onboarding::set_bool(&world.db.write, &key, *status).await?;
     Ok(())
 }
 
@@ -39,7 +39,7 @@ async fn then_onboarding_step(
     key: String,
     expected: parameters::Bool,
 ) -> anyhow::Result<()> {
-    let status = onboarding::get_bool(world.db(), &key).await?;
+    let status = onboarding::get_bool(&world.db.write, &key).await?;
     assert_eq!(status, Some(*expected));
     Ok(())
 }

--- a/src/rest-api/tests/features/server_config.rs
+++ b/src/rest-api/tests/features/server_config.rs
@@ -24,7 +24,7 @@ use super::prelude::*;
 async fn given_server_config_in_db(world: &mut TestWorld, step: &Step) -> anyhow::Result<()> {
     let json = step.docstring().unwrap().trim();
     let map = serde_json::from_str(json)?;
-    global_storage::kv_store::set_map(world.db(), "server_config", map).await?;
+    global_storage::kv_store::set_map(&world.db.write, "server_config", map).await?;
     Ok(())
 }
 
@@ -207,7 +207,7 @@ async fn given_file_uploading(
     world: &mut TestWorld,
     state: parameters::ToggleState,
 ) -> anyhow::Result<()> {
-    server_config::file_upload_allowed::set(world.db(), state.into()).await?;
+    server_config::file_upload_allowed::set(&world.db.write, state.into()).await?;
     Ok(())
 }
 
@@ -216,7 +216,7 @@ async fn given_file_retention(
     world: &mut TestWorld,
     duration: parameters::Duration,
 ) -> anyhow::Result<()> {
-    server_config::file_storage_retention::set(world.db(), duration.into()).await?;
+    server_config::file_storage_retention::set(&world.db.write, duration.into()).await?;
     Ok(())
 }
 
@@ -300,7 +300,7 @@ async fn given_server_config<F, R>(
 where
     F: Future<Output = anyhow::Result<R>> + 'static,
 {
-    update(world.db.clone()).await?;
+    update(world.db.write.clone()).await?;
     world.server_config_manager().reload().await?;
     world.reset_server_ctl_counts();
     Ok(())

--- a/src/rest-api/tests/prose.toml
+++ b/src/rest-api/tests/prose.toml
@@ -14,7 +14,6 @@ domain = "test.org"
 smtp_host = "test.org"
 
 [api.databases.main]
-url = "sqlite::memory:"
 sqlx_logging = true
 
 [debug_only.dependency_modes]

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -78,6 +78,7 @@ xmpp-parsers = { workspace = true }
 [dev-dependencies]
 cucumber = { workspace = true, features = ["macros"] }
 insta = { workspace = true }
+figment = { version = "*", features = ["json"] }
 
 [features]
 default = []

--- a/src/service/src/features/app_config/defaults.rs
+++ b/src/service/src/features/app_config/defaults.rs
@@ -231,36 +231,33 @@ pub mod notifiers {
 pub mod databases {
     use crate::app_config::{DatabaseConfig, API_DATA_DIR};
 
-    pub fn main() -> DatabaseConfig {
+    pub fn main_url() -> String {
+        format!("sqlite://{API_DATA_DIR}/database.sqlite")
+    }
+
+    pub fn main_read() -> DatabaseConfig {
         DatabaseConfig {
-            url: format!("sqlite://{API_DATA_DIR}/database.sqlite"),
-            min_connections: Default::default(),
+            url: main_url(),
+            min_connections: None,
             max_connections: default::max_connections(),
             connect_timeout: default::connect_timeout(),
-            idle_timeout: Default::default(),
-            sqlx_logging: Default::default(),
+            acquire_timeout: None,
+            idle_timeout: None,
+            sqlx_logging: false,
         }
+    }
+
+    pub fn main_write() -> DatabaseConfig {
+        let mut main_write = main_read();
+        main_write.max_connections = 1;
+        main_write
     }
 
     pub mod default {
         pub fn max_connections() -> usize {
-            // BUG: See [“database is locked” when two server configs are reset concurrently · Issue #327 · prose-im/prose-pod-api](https://github.com/prose-im/prose-pod-api/issues/327).
-            // let workers: usize =
-            //     std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
-            // workers * 4
-
-            if cfg!(feature = "test") {
-                // FIX: See [prose-pod-api#327 (comment)](https://github.com/prose-im/prose-pod-api/issues/327#issuecomment-3292783517).
-                4
-            } else {
-                // BUG: See [“database is locked” when two server configs are reset concurrently · Issue #327 · prose-im/prose-pod-api](https://github.com/prose-im/prose-pod-api/issues/327).
-                // let workers: usize =
-                //     std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
-                // workers * 4
-
-                // FIX: See [prose-pod-api#327 (comment)](https://github.com/prose-im/prose-pod-api/issues/327#issuecomment-3291683089).
-                1
-            }
+            let workers: usize =
+                std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+            workers * 4
         }
 
         pub fn connect_timeout() -> u64 {

--- a/src/service/src/features/auth/util.rs
+++ b/src/service/src/features/auth/util.rs
@@ -3,7 +3,6 @@
 // Copyright: 2024–2025, Rémi Bardon <remi@remibardon.name>
 // License: Mozilla Public License v2.0 (MPL v2.0)
 
-use rand::{distributions::Alphanumeric, thread_rng, Rng as _};
 use secrecy::SecretString;
 
 /// Generates a random secret string.
@@ -11,13 +10,7 @@ use secrecy::SecretString;
 pub fn random_secret(length: usize) -> SecretString {
     assert!(length >= 16);
 
-    // NOTE: Code taken from <https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html#create-random-passwords-from-a-set-of-alphanumeric-characters>.
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect::<String>()
-        .into()
+    crate::util::random_string_alphanumeric(length).into()
 }
 
 /// Generates a random secret string (URL-safe).

--- a/src/service/src/features/cron/mod.rs
+++ b/src/service/src/features/cron/mod.rs
@@ -9,11 +9,10 @@ mod refresh_service_accounts_tokens;
 use std::sync::Arc;
 
 use futures::future::join_all;
-use sea_orm::DatabaseConnection;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, Instrument as _};
 
-use crate::AppConfig;
+use crate::{models::DatabaseRwConnectionPools, AppConfig};
 
 use super::{auth::AuthService, secrets::SecretsStore};
 
@@ -21,7 +20,7 @@ use super::{auth::AuthService, secrets::SecretsStore};
 pub struct CronContext {
     pub cancellation_token: CancellationToken,
     pub app_config: Arc<AppConfig>,
-    pub db: DatabaseConnection,
+    pub db: DatabaseRwConnectionPools,
     pub secrets_store: SecretsStore,
     pub auth_service: AuthService,
 }

--- a/src/service/src/features/members/member_service.rs
+++ b/src/service/src/features/members/member_service.rs
@@ -7,14 +7,14 @@ use std::{cmp::min, collections::HashSet, sync::Arc};
 
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, ItemsAndPagesNumber, Iterable};
+use sea_orm::{ConnectionTrait, DbErr, ItemsAndPagesNumber, Iterable};
 use serdev::Serialize;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, instrument, trace, trace_span, warn, Instrument};
 
 use crate::{
     app_config::MemberEnrichingConfig,
-    models::AvatarOwned,
+    models::{AvatarOwned, DatabaseRwConnectionPools},
     util::{unaccent, Cache, ConcurrentTaskRunner},
     xmpp::{BareJid, ServerCtl, ServerCtlError, XmppService},
 };
@@ -28,7 +28,7 @@ struct VCardData {
 
 #[derive(Debug, Clone)]
 pub struct MemberService {
-    db: Arc<DatabaseConnection>,
+    db: DatabaseRwConnectionPools,
     server_ctl: Arc<ServerCtl>,
     xmpp_service: Arc<XmppService>,
     pub cancellation_token: CancellationToken,
@@ -47,7 +47,7 @@ pub struct MemberServiceContext {
 
 impl MemberService {
     pub fn new(
-        db: Arc<DatabaseConnection>,
+        db: DatabaseRwConnectionPools,
         server_ctl: Arc<ServerCtl>,
         xmpp_service: Arc<XmppService>,
         concurrent_task_runner: ConcurrentTaskRunner,
@@ -131,7 +131,7 @@ impl MemberService {
         until: Option<DateTime<Utc>>,
     ) -> Result<(ItemsAndPagesNumber, Vec<Member>), anyhow::Error> {
         let (metadata, members) =
-            MemberRepository::get_page(self.db.as_ref(), page_number, page_size, until)
+            MemberRepository::get_page(&self.db.read, page_number, page_size, until)
                 .await
                 .context("Database error")?;
         Ok((metadata, members.into_iter().map(Into::into).collect()))
@@ -145,7 +145,7 @@ impl MemberService {
         until: Option<DateTime<Utc>>,
     ) -> Result<(ItemsAndPagesNumber, Vec<EnrichedMember>), anyhow::Error> {
         // Get **all** members from database (no details).
-        let members = MemberRepository::get_all_until(self.db.as_ref(), until)
+        let members = MemberRepository::get_all_until(&self.db.read, until)
             .await
             .context("Database error")?;
 
@@ -239,8 +239,9 @@ impl MemberService {
         jid: &BareJid,
         role: MemberRole,
     ) -> anyhow::Result<Option<MemberRole>> {
-        let new_role =
-            (MemberRepository::set_role(self.db.as_ref(), jid, role).await?).replace(role);
+        let new_role = MemberRepository::set_role(&self.db.write, jid, role)
+            .await?
+            .replace(role);
 
         // NOTE: We can't rollback changes made to the XMPP server so we do it
         //   after "rollbackable" DB changes in case they fail. It's not perfect
@@ -260,7 +261,7 @@ impl MemberService {
     pub async fn enrich_jid(&self, jid: &BareJid) -> Result<Option<EnrichedMember>, anyhow::Error> {
         trace!("Enriching `{jid}`…");
 
-        let member = match MemberRepository::get(self.db.as_ref(), jid).await {
+        let member = match MemberRepository::get(&self.db.read, jid).await {
             Ok(Some(entity)) => entity,
             Ok(None) => {
                 warn!("Member '{jid}' does not exist in database. Won't try enriching it with XMPP data.");

--- a/src/service/src/models/db.rs
+++ b/src/service/src/models/db.rs
@@ -1,0 +1,29 @@
+// prose-pod-api
+//
+// Copyright: 2025, Rémi Bardon <remi@remibardon.name>
+// License: Mozilla Public License v2.0 (MPL v2.0)
+
+use sea_orm::DatabaseConnection;
+
+/// Separated read/write database connection pools.
+///
+/// This allows using different settings for both (e.g. at most one connection
+/// for writing, and a higher number for concurrent reading).
+///
+/// This split was motivated by
+/// [“database is locked” when two server configs are reset concurrently · Issue #327 · prose-im/prose-pod-api](https://github.com/prose-im/prose-pod-api/issues/327)
+/// and [Database now locks more often · Issue #331 · prose-im/prose-pod-api](https://github.com/prose-im/prose-pod-api/issues/331),
+/// and suggested in
+/// [launchbadge/sqlx#451 (comment)](https://github.com/launchbadge/sqlx/issues/451#issuecomment-649866619).
+// FIXME: Make this type-safe. I (@RemiBardon) had to go fast but this looks
+//   like a huge footgun. One day we’ll have a bug because we passed a read-only
+//   connection to a function that at some point tries to write something and
+//   that’ll be my fault for not making this type safe from the start.
+//   When we do this, also make sure the read pool is read-only. I didn’t
+//   do it because we have no type safety ATM and it would just increase the
+//   probability of a footgun.
+#[derive(Debug, Clone)]
+pub struct DatabaseRwConnectionPools {
+    pub read: DatabaseConnection,
+    pub write: DatabaseConnection,
+}

--- a/src/service/src/models/mod.rs
+++ b/src/service/src/models/mod.rs
@@ -6,6 +6,7 @@
 mod atoms;
 mod avatar;
 mod color;
+mod db;
 pub mod durations;
 mod email_address;
 mod lua;
@@ -20,6 +21,7 @@ pub mod xmpp;
 pub use self::atoms::*;
 pub use self::avatar::*;
 pub use self::color::*;
+pub use self::db::*;
 pub use self::durations::*;
 pub use self::email_address::*;
 pub use self::lua::*;

--- a/src/service/src/util/mod.rs
+++ b/src/service/src/util/mod.rs
@@ -74,3 +74,20 @@ macro_rules! wrapper_type {
         }
     };
 }
+
+/// Generates a random string.
+///
+/// WARN: Do not generate secrets with this function! Instead, use
+///   [`crate::auth::util::random_secret`].
+#[must_use]
+#[inline]
+pub fn random_string_alphanumeric(length: usize) -> String {
+    use rand::{distributions::Alphanumeric, Rng as _};
+
+    // NOTE: Code taken from <https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html#create-random-passwords-from-a-set-of-alphanumeric-characters>.
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect::<String>()
+}

--- a/src/service/tests/prose.toml
+++ b/src/service/tests/prose.toml
@@ -13,9 +13,6 @@ domain = "test.org"
 [notifiers.email]
 smtp_host = "test.org"
 
-[api.databases.main]
-url = "sqlite::memory:"
-
 [auth]
 oauth2_registration_key = "dummy-test-key"
 


### PR DESCRIPTION
Fixes #331. See rationale there, on #327 and #317.
Also closes #328.

Turns out this was a rabbit hole, especially regarding tests, but I managed to fix all database locks without any breaking change (even configuration-wise).

Smoke tests and integration tests helped a lot in catching subtle bugs I could have introduced, like breaking factory resets by mistake (special case where we close and recreate the connections).

As said in `service::models::db` this fix isn’t type safe, but it’s at least FAR better than what we had before, and is very unlikely to cause new locks:

```rs
// FIXME: Make this type-safe. I (@RemiBardon) had to go fast but this looks
//   like a huge footgun. One day we’ll have a bug because we passed a read-only
//   connection to a function that at some point tries to write something and
//   that’ll be my fault for not making this type safe from the start.
//   When we do this, also make sure the read pool is read-only. I didn’t
//   do it because we have no type safety ATM and it would just increase the
//   probability of a footgun.
```